### PR TITLE
Minor fixes to example 1 & 2

### DIFF
--- a/examples/example1.html
+++ b/examples/example1.html
@@ -72,9 +72,9 @@
     function isOutsideCanvas(item) { return (item.x < 0 || item.y < 0 || item.x > canvas.width || item.y > canvas.height) }
     function forceInsideCanvas(item) {
       if(item.x < 0)                    { item.x = 0  }
-      if(item.right > canvas.width)     { item.x = canvas.width - item.width }
+      if(item.x + item.width > canvas.width)     { item.x = canvas.width - item.width }
       if(item.y < 0)                    { item.y = 0 }
-      if(item.bottom  > canvas.height)  { item.y = canvas.height - item.height }
+      if(item.y + item.height  > canvas.height)  { item.y = canvas.height - item.height }
     }
 
     /* Our simple bullet class, basically a circle with a position (x/y) */

--- a/examples/example2.html
+++ b/examples/example2.html
@@ -74,9 +74,9 @@
       }
       function forceInsideCanvas(item) {
         if(item.x < 0)                  { item.x = 0  }
-        if(item.right > jaws.width)     { item.x = jaws.width - item.width }
+        if(item.x + item.width > jaws.width)     { item.x = jaws.width - item.width }
         if(item.y < 0)                  { item.y = 0 }
-        if(item.bottom  > jaws.height)  { item.y = jaws.height - item.height }
+        if(item.y + item.height  > jaws.height)  { item.y = jaws.height - item.height }
       }
 
       function Bullet(x, y) {


### PR DESCRIPTION
Change 'item.right' to 'item.x + item.width' and change 'item.bottom'
to 'item.y + item.height', since 'Sprites' class does not seem to
have those two properties.
