### PR TITLE
Rewrite SpriteList to use an internal sprites array

### DIFF
--- a/src/collision_detection.js
+++ b/src/collision_detection.js
@@ -39,7 +39,7 @@ jaws.collideOneWithMany = function(object, list) {
  *
  * @example
  *
- *   jaws.collideManyWithMany(bullets, enemies) // --> [[bullet, ememy], [bullet, enemy]]
+ *   jaws.collideManyWithMany(bullets, enemies) // --> [[bullet, enemy], [bullet, enemy]]
  *
  */
 jaws.collideManyWithMany = function(list1, list2) {
@@ -53,7 +53,7 @@ jaws.collideManyWithMany = function(list1, list2) {
   else {
     list1.forEach( function(item1) { 
       list2.forEach( function(item2) { 
-        if(jaws.collideOneWithOne(item1, item2)) a.push([item1, item2]) 
+        if(jaws.collideOneWithOne(item1, item2)) a.push([item1, item2])
       });
     });
   }
@@ -86,12 +86,18 @@ jaws.distanceBetween = function(object1, object2) {
 }
 
 /** private */
-function combinations(s, n) {
-  var f = function(i){return s[i];};
+function combinations(list, n) {
+  var f = function(i) {
+    if(list.isSpriteList !== undefined) {
+      return list.at(i)
+    } else {  // s is an Array
+      return list[i];
+    }
+  };
   var r = [];
   var m = new Array(n);
   for (var i = 0; i < n; i++) m[i] = i; 
-  for (var i = n - 1, sn = s.length; 0 <= i; sn = s.length) {
+  for (var i = n - 1, sn = list.length; 0 <= i; sn = list.length) {
     r.push( m.map(f) );
     while (0 <= i && m[i] == sn - 1) { i--; sn--; }
     if (0 <= i) { 

--- a/src/sprite_list.js
+++ b/src/sprite_list.js
@@ -1,7 +1,7 @@
 var jaws = (function(jaws) {
 /**
  
-@class Manages all your Sprites in lists. Makes easy mass-draw() / update() possible among others. Builds on Array. "Field Summary" contains options for the SpriteList()-constructor.
+@class Manages all your Sprites in lists. Makes easy mass-draw() / update() possible among others. Implements Array API. "Field Summary" contains options for the SpriteList()-constructor.
 
 @example
 // Sprites (your bullets, aliens, enemies, players etc) will need to be
@@ -14,30 +14,170 @@ for(i=0; i < 100; i++) {
   enemies.push(new Sprite({image: "enemy.png", x: i, y: 200}))
 }
 enemies.draw()                    // calls draw() on all enemies 
-enemies.deleteIf(isOutsideCanvas) // deletes each item in enemies that returns true when isOutsideCanvas(item) is called
+enemies.removeIf(isOutsideCanvas) // removes each item in enemies that returns true when isOutsideCanvas(item) is called
 enemies.drawIf(isInsideViewport)  // only call draw() on items that returns true when isInsideViewport is called with item as argument 
 
 */
 jaws.SpriteList = function SpriteList(options) {
+  // Make both sprite_list = new SpriteList() and sprite_list = SpriteList() work
   if( !(this instanceof arguments.callee) ) return new arguments.callee( options );
 
+  this.sprites = []
+  this.length = 0
+  
   if(options) this.load(options);
 }
-jaws.SpriteList.prototype = new Array
 
 /**
- *
- * load sprites into sprite list.
+ * Return the sprite at the specified index.
+ * Replaces the array [] notation.
+ * So:
+ * my_sprite_list.at(1) is equivalent to my_array[1]
+ * 
+ * @param {integer} index
+ * @returns Element at index
+ */
+jaws.SpriteList.prototype.at = function(index) {
+  return this.sprites[index]
+}
+
+// Implement the Array API functions
+
+jaws.SpriteList.prototype.concat = function() {
+  return this.sprites.concat.apply(this.sprites, arguments)
+}
+
+jaws.SpriteList.prototype.indexOf = function(searchElement, fromIndex) {
+  return this.sprites.indexOf(searchElement, fromIndex)
+}
+
+/**
+ * Joins the contents of the sprite list into a string.
+ * 
+ * Implemented mostly for an easy verbose way to display the sprites 
+ * inside the sprite list.
+ */
+jaws.SpriteList.prototype.join = function(separator) {
+  return this.sprites.join(separator)
+}
+
+jaws.SpriteList.prototype.lastIndexOf = function() {
+  return this.sprites.lastIndexOf.apply(this.sprites, arguments)
+}
+
+jaws.SpriteList.prototype.pop = function() {
+  var element = this.sprites.pop()
+  this.updateLength()
+  return element
+}
+
+jaws.SpriteList.prototype.push = function() {
+  this.sprites.push.apply(this.sprites, arguments)
+  this.updateLength()
+  return this.length
+}
+
+jaws.SpriteList.prototype.reverse = function() {
+  this.sprites.reverse()
+}
+
+jaws.SpriteList.prototype.shift = function() {
+  var element = this.sprites.shift()
+  this.updateLength()
+  return element
+}
+
+jaws.SpriteList.prototype.slice = function(start, end) {
+  return this.sprites.slice(start, end)
+}
+
+jaws.SpriteList.prototype.sort = function() {
+  this.sprites.sort.apply(this.sprites, arguments)
+}
+
+jaws.SpriteList.prototype.splice = function() {
+  this.sprites.splice.apply(this.sprites, arguments)
+  this.updateLength()
+}
+
+jaws.SpriteList.prototype.unshift = function() {
+  this.sprites.unshift.apply(this.sprites, arguments)
+  this.updateLength()
+  return this.length
+}
+
+jaws.SpriteList.prototype.updateLength = function() {
+  this.length = this.sprites.length
+}
+
+jaws.SpriteList.prototype.valueOf = function() {
+  return this.toString()
+}
+
+// Implement "extras" / standardized Array functions
+// See http://dev.opera.com/articles/view/javascript-array-extras-in-detail/ for discussion, browser compatibility
+
+// Does not mutate
+jaws.SpriteList.prototype.filter = function() {
+  return this.sprites.filter.apply(this.sprites, arguments)
+}
+
+jaws.SpriteList.prototype.forEach = function() {
+  this.sprites.forEach.apply(this.sprites, arguments)
+  this.updateLength()  // in case the forEach operation changes the sprites array
+}
+
+// Does not mutate
+jaws.SpriteList.prototype.every = function() {
+  return this.sprites.every.apply(this.sprites, arguments)
+}
+
+// Does not mutate
+jaws.SpriteList.prototype.map = function() {
+  return this.sprites.map.apply(this.sprites, arguments)
+}
+
+// Does not mutate
+jaws.SpriteList.prototype.reduce = function() {
+  return this.sprites.reduce.apply(this.sprites, arguments)
+}
+
+// Does not mutate
+jaws.SpriteList.prototype.reduceRight = function() {
+  return this.sprites.reduceRight.apply(this.sprites, arguments)
+}
+
+// Does not mutate
+jaws.SpriteList.prototype.some = function() {
+  return this.sprites.some.apply(this.sprites, arguments)
+}
+
+jaws.SpriteList.prototype.isSpriteList = function() {
+  return true;
+}
+
+/**
+ * Load sprites into sprite list.
  *
  * Argument could either be
+ * - an array of Sprite objects
  * - an array of JSON objects
  * - a JSON.stringified string representing an array of JSON objects
  *
  */
 jaws.SpriteList.prototype.load = function(objects) {
   var that = this;  // Since forEach changes this into DOMWindow.. hm, lame.
-  if(jaws.isArray(objects))       { parseArray(objects) }
+  if(jaws.isArray(objects)) {
+    // If this is an array of JSON representations, parse it
+    if(objects.every(function(item) { return jaws.isArray(item) })) {
+      parseArray(objects)
+    } else {
+      // This is an array of Sprites, load it directly
+      this.sprites = objects
+    }
+  }
   else if(jaws.isString(objects)) { parseArray( JSON.parse(objects) ) }
+  this.updateLength()
   
   function parseArray(array) {
     array.forEach( function(data) {
@@ -52,55 +192,60 @@ jaws.SpriteList.prototype.load = function(objects) {
   }
 }
 
-/** Remove obj from list */
+/** Removes the first occurrence of obj from list */
 jaws.SpriteList.prototype.remove = function(obj) {
   var index = this.indexOf(obj)
   if(index > -1) { this.splice(index, 1) }
+  this.updateLength()
 }
 
 /** Draw all sprites in spritelist */
 jaws.SpriteList.prototype.draw = function() {
-  for(i=0; this[i]; i++) { 
-    this[i].draw() 
-  }
+  this.forEach(function(ea) {
+    ea.draw()
+  })
 }
 
 /** Draw sprites in spritelist where condition(sprite) returns true */
 jaws.SpriteList.prototype.drawIf = function(condition) {
-  for(i=0; this[i]; i++) {
-    if( condition(this[i]) ) { this[i].draw() }
-  }
+  this.forEach(function(ea) {
+    if( condition(ea) ) {
+      ea.draw()
+    }
+  })
 }
 
 /** Call update() on all sprites in spritelist */
 jaws.SpriteList.prototype.update = function() {
-  for(i=0; this[i]; i++) {
-    this[i].update()
-  }
+  this.forEach(function(ea) {
+    ea.update()
+  })
 }
 
 /** Call update() on sprites in spritelist where condition(sprite) returns true */
 jaws.SpriteList.prototype.updateIf = function(condition) {
-  for(i=0; this[i]; i++) {
-    if( condition(this[i]) ) { this[i].update() }
-  }
+  this.forEach(function(ea) {
+    if( condition(ea) ) {
+      ea.update()
+    }
+  })
 }
 
 /** 
- * Delete sprites in spritelist where condition(sprite) returns true 
+ * Delete sprites in spritelist where condition(sprite) returns true.
+ * Alias for removeIf()
  * @deprecated
  */
 jaws.SpriteList.prototype.deleteIf = function(condition) {
-  for(var i=0; this[i]; i++) {
-    if( condition(this[i]) ) { this.splice(i,1) }
-  }
+  this.removeIf(condition)
 }
 
 /** Remove sprites in spritelist where condition(sprite) returns true  */
 jaws.SpriteList.prototype.removeIf = function(condition) {
-  for(var i=0; this[i]; i++) {
-    if( condition(this[i]) ) { this.splice(i,1) }
-  }
+  this.sprites = this.filter(function(ea) {
+    return !condition(ea)
+  })
+  this.updateLength()
 }
 
 jaws.SpriteList.prototype.toString = function() { return "[SpriteList " + this.length + " sprites]" }

--- a/test/collision_detection.js
+++ b/test/collision_detection.js
@@ -35,6 +35,7 @@ test("Collision detection", function() {
   
   // Test collideOneWithMany and collideManyWithMany on SpriteLists
   var sprite_list = new jaws.SpriteList([sprite1, sprite2, sprite3])
+
   same( jaws.collideOneWithMany(sprite1, sprite_list), [sprite2], "collideOneWithMany sprite_list rect")
   same( jaws.collideManyWithMany(sprite_list, sprite_list), [[sprite1, sprite2]], "collideManyWithMany sprite_list rect")
   

--- a/test/sprite_list.js
+++ b/test/sprite_list.js
@@ -3,6 +3,10 @@ module("Sprite List")
 test("Empty Sprite List", function() {
   var sprite_list = new jaws.SpriteList()
   same(sprite_list.length, 0, "should start with zero sprites")
+  
+  // This bit is relevant for collision_detection/combinations() to work
+  ok(!jaws.isArray(sprite_list), "sprite_list is NOT an array")
+  ok(sprite_list.isSpriteList(), "isSpriteList() == true")
 })
 
 test("Load Objects", function() {
@@ -19,14 +23,17 @@ test("Load Objects", function() {
   
   sprite_list.load([sprite_one, sprite_two])
   same(sprite_list.length, 2, "should contain two sprites after loading")
+  same(sprite_list.at(0).x, 10)
+  same(sprite_list.at(1).x, 20)
 
-  ok(sprite_list[0].width, 'sprite_one should have a width, after being loaded into a SpriteList')
-  ok(sprite_list[1].width, 'sprite_two should have a width, after being loaded into a SpriteList')
+  ok(sprite_list.at(0).width, 'sprite_one should have a width, after being loaded into a SpriteList')
+  ok(sprite_list.at(1).width, 'sprite_two should have a width, after being loaded into a SpriteList')
   
   var new_sprite_list = new jaws.SpriteList([sprite_one, sprite_two])
   same(new_sprite_list.length, 2, "should contain two sprites after loading (via constructor)")
-  ok(new_sprite_list[0].width, 'sprite_one should have a width, after being loaded into a SpriteList')
-  ok(new_sprite_list[1].width, 'sprite_two should have a width, after being loaded into a SpriteList')
+  same(sprite_list.at(0).x, 10)
+  same(sprite_list.at(1).x, 20)
+  
 })
 
 test("Push and toString", function() {
@@ -167,6 +174,21 @@ test("deleteIf()", function() {
   sprite_list.deleteIf(true_condition)
   same(sprite_list.length, 0, "should have a length of 0, after deleteIf(true_condition)")
 })
+
+test("at()", function() {
+  var sprite_list = new jaws.SpriteList()
+  var sprite = new jaws.Sprite({image: "rect.png"})
+  sprite.x = 10
+  var sprite_two = new jaws.Sprite({image: "rect.png"})
+  sprite_two.x = 20
+  sprite_list.push(sprite)
+  sprite_list.push(sprite_two)
+  
+  same(sprite_list.at(0), sprite, "sprite_list.at(0) should == sprite")
+  same(sprite_list.at(0).x, 10, "sprite_list.at(0).x should == sprite.x")
+  same(sprite_list.at(1), sprite_two, "sprite_list.at(1) should == sprite_two")
+})
+
 
 // Test some Array API / standardized functions
 test("filter()", function() {


### PR DESCRIPTION
ippa,
Here's the SpriteList rewrite, plus some more tests to go with it.

Things to note:
- Now uses an internal array called 'sprites' to store the sprites, instead of using Array in its prototype chain
- Implements the full Array API, delegates calls to the 'sprites' attribute
- I added tests to make sure the new sprite lists work with collision detection
- The only thing that this breaks is direct array-like access, ie `sprite_list[0]`  (this is replaced, for the few internal methods that need it, with `sprite_list.at(0)` ). This is a bit unfortunate, but I don't see how it can be avoided. 

This could stand to have a lot more jsdocs / function comments, but I wanted to first run this by you, before putting those in.
