### PR TITLE
ADD: pass options to game state's setup() method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -162,7 +162,7 @@ function saveMousePosition(e) {
  *  // It's recommended not giving fps-option to jaws.start since then it will default to 60 FPS and using requestAnimationFrame when possible.
  *
  */
-jaws.start = function(game_state, options,game_object_setup_options) {
+jaws.start = function(game_state, options,game_state_setup_options) {
   if(!options) options = {};
   var fps = options.fps || 60
   if (options.loading_screen === undefined)
@@ -204,7 +204,7 @@ jaws.start = function(game_state, options,game_object_setup_options) {
   /* Callback for when all assets are loaded */
   function assetsLoaded() {
     jaws.log("all assets loaded", true)
-    jaws.switchGameState(game_state||window, {fps: fps},game_object_setup_options)
+    jaws.switchGameState(game_state||window, {fps: fps},game_state_setup_options)
   }
 
   jaws.log("assets.loadAll()", true)
@@ -235,7 +235,7 @@ jaws.start = function(game_state, options,game_object_setup_options) {
 * jaws.start(MenuState)
 *
 */
-jaws.switchGameState = function(game_state, options,game_object_setup_options) {
+jaws.switchGameState = function(game_state, options,game_state_setup_options) {
   var fps = (options && options.fps) || (jaws.game_loop && jaws.game_loop.fps) || 60
   
   jaws.game_loop && jaws.game_loop.stop()
@@ -244,7 +244,7 @@ jaws.switchGameState = function(game_state, options,game_object_setup_options) {
   
   jaws.previous_game_state = jaws.game_state
   jaws.game_state = game_state
-  jaws.game_loop = new jaws.GameLoop(game_state, {fps: fps},game_object_setup_options)
+  jaws.game_loop = new jaws.GameLoop(game_state, {fps: fps},game_state_setup_options)
   jaws.game_loop.start()
 }
 

--- a/src/game_loop.js
+++ b/src/game_loop.js
@@ -32,7 +32,7 @@ window.requestAnimFrame = (function(){
  * jaws.start(MyGameState, {fps: 30})
  *
  */
-jaws.GameLoop = function GameLoop(game_object, options,game_object_setup_options) {
+jaws.GameLoop = function GameLoop(game_object, options,game_state_setup_options) {
   if( !(this instanceof arguments.callee) ) return new arguments.callee( game_object, options );
 
   this.ticks = 0
@@ -61,7 +61,7 @@ jaws.GameLoop = function GameLoop(game_object, options,game_object_setup_options
     this.current_tick = (new Date()).getTime();
     this.last_tick = (new Date()).getTime(); 
 
-    if(game_object.setup) { game_object.setup(game_object_setup_options) }
+    if(game_object.setup) { game_object.setup(game_state_setup_options) }
     step_delay = 1000 / options.fps;
    
     if(options.fps == 60) {


### PR DESCRIPTION
jaws.start() and jaws.switchGameState() now accept a third parameter which is passed to game state's setup() method
