### PR TITLE
Code reuse and a question

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -72,7 +72,7 @@ jaws.Viewport = function ViewPort(options) {
 
   /** Returns true if item is inside viewport  */
   this.isInside = function(item) {
-    return( item.x >= that.x && item.x <= (that.x + that.width) && item.y >= that.y && item.y <= (that.y + that.height) )
+    return( (! that.isLeftOf(item)) && (! that.isRightOf(item)) && (! that.isAbove(item)) && (! that.isBelow(item)) )
   };
 
   /** Returns true if item is partly (down to 1 pixel) inside viewport */


### PR DESCRIPTION
Can reuse existing method logic instead of recreating them in inverse, and is there a reason that item.rect().width and item.rect().height is not taken into account for isRightOf and isBelow? ..... This question extends to forceInside? 

So basically, the only reason I noticed the code reuse issue is that I was trying to understand why I had to adjust by the width of the sprite to check if the player was to the right of the viewport but not to the left... So my question is, feature or bug?
