### PR TITLE
Fixed blocking mouse events to be active on canvas only.

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -85,8 +85,8 @@ jaws.setupInput = function() {
 
   window.addEventListener("keydown", handleKeyDown)
   window.addEventListener("keyup", handleKeyUp)
-  window.addEventListener("mousedown", handleMouseDown, false);
-  window.addEventListener("mouseup", handleMouseUp, false);
+  jaws.canvas.addEventListener("mousedown", handleMouseDown, false);
+  jaws.canvas.addEventListener("mouseup", handleMouseUp, false);
   window.addEventListener("touchstart", handleTouchStart, false);
   window.addEventListener("touchend", handleTouchEnd, false);
   window.addEventListener("blur", resetPressedKeys, false);


### PR DESCRIPTION
Currently the mouse events have handled = true on them and therefore the page (entire window) becomes unresponsive to mouse clicks if you register on the mouseup/mousedown events. I moved the event registration to the canvas only.

I will make a similar fix to touchup and touchdown once I figure out why they don't work on Safari.
