### PR TITLE
Collide should always return a boolean value

### DIFF
--- a/src/collision_detection.js
+++ b/src/collision_detection.js
@@ -145,9 +145,9 @@ function hasItems(array) { return (array && array.length > 0) }
  *
  */
 jaws.collide = function(x, x2, callback) {
-  if(x.rect     && x2.forEach)  return jaws.collideOneWithMany(x, x2, callback);
-  if(x.forEach  && x2.forEach)  return jaws.collideManyWithMany(x, x2, callback);
-  if(x.forEach  && x2.rect)     return jaws.collideOneWithMany(x2, x, callback);
+  if(x.rect     && x2.forEach)  return (jaws.collideOneWithMany(x, x2, callback)===[]);
+  if(x.forEach  && x2.forEach)  return (jaws.collideManyWithMany(x, x2, callback)===[]);
+  if(x.forEach  && x2.rect)     return (jaws.collideOneWithMany(x2, x, callback)===[]);
   if(x.rect && x2.rect && jaws.collideOneWithOne(x,x2)) callback(x, x2);
 }
 


### PR DESCRIPTION
I've been working on QuadTree and noticed that the results from a call to jaws.collide varied depending on the combination of list or sprites.

This patch will always return either true or false no matter what combination is used, not just for sprite on sprite collision cases.
