### PR TITLE
Text: Fixed position bug; added shadow effects

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -379,7 +379,6 @@ var jaws = (function(jaws) {
             return this.updateDiv();
         }
         this.context.save();
-        this.context.translate(this.x, this.y);
         if (this.angle !== 0) {
             this.context.rotate(this.angle * Math.PI / 180);
         }


### PR DESCRIPTION
I've been using Text a great deal more for descriptions of things in the adventure game I'm working on and noticed that the positioning kept being slightly off. After working with it some, I found out the initial translate to its x and y was then pushing the final fillText call off by the difference between the origin and the translate. (The problem is fixed by removing the translate.)

I've also added shadow effects to Text. While any canvas drawing call can use them, they work much better (and have a more general use case) for drawing text than for sprites or even lines.
