### PR TITLE
Update core.js: Docs, Fixes

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,15 +1,6 @@
 /**
- * @namespace JawsJS core functions. "Field Summary" contains readable properties on the main jaws-object.
+ * @namespace JawsJS core functions.
  *
- * @property {int} mouse_x  Mouse X position with respect to the canvas-element
- * @property {int} mouse_y  Mouse Y position with respect to the canvas-element
- * @property {canvas} canvas  The detected/created canvas-element used for the game
- * @property {context} context  The detected/created canvas 2D-context, used for all draw-operations
- * @property {int} width  Width of the canvas-element
- * @property {int} height  Height of the canvas-element
- *
- *
- * @example
  * Jaws, a HTML5 canvas/javascript 2D game development framework
  *
  * Homepage:      http://jawsjs.com/
@@ -27,352 +18,512 @@
  *   jaws.one_variable = 1
  *   new jaws.OneConstructor
  *
- * Have fun! 
- *
- * ippa. 
- *
+ * @property {int}      mouse_x     Mouse X position with respect to the canvas-element
+ * @property {int}      mouse_y     Mouse Y position with respect to the canvas-element
+ * @property {canvas}   canvas      The detected/created canvas-element used for the game
+ * @property {context}  context     The detected/created canvas 2D-context, used for all draw-operations
+ * @property {int}      width       Width of the canvas-element
+ * @property {int}      height      Height of the canvas-element
  */
 var jaws = (function(jaws) {
 
-var title
-var log_tag  
+  var title;
+  var log_tag;
 
-jaws.title = function(value) {
-  if(value) { return (title.innerHTML = value) }
-  return title.innerHTML
-}
+  /**
+   * Returns or sets contents of title's innerHTML
+   * @private
+   * @param   {type}   value  The new value to set the innerHTML of title
+   * @returns {string}        The innerHTML of title
+   */
+  jaws.title = function(value) {
 
-/**
- * Unpacks Jaws core-constructors into the global namespace. If a global property is allready taken, a warning will be written to jaws log.
- * After calling jaws.unpack() you can use <b>Sprite()</b> instead of <b>jaws.Sprite()</b>, <b>Animation()</b> instead of <b>jaws.Animation()</b> and so on.
- *
- */
-jaws.unpack = function() {
-  var make_global = ["Sprite", "SpriteList", "Animation", "Viewport", "SpriteSheet", "Parallax", "TileMap", "Rect", "pressed"]
+    if (!jaws.isString(value)) {
+      jaws.log("jaws.title: Passed in value is not a String.");
+      return;
+    }
 
-  make_global.forEach( function(item, array, total) {
-    if(window[item])  { jaws.log(item + "already exists in global namespace") }
-    else              { window[item] = jaws[item] }
-  });
-}
+    if (value) {
+      return (title.innerHTML = value);
+    }
+    return title.innerHTML;
+  };
 
+  /**
+   * Unpacks Jaws core-constructors into the global namespace.
+   * If a global property is already taken, a warning will be written to jaws log.
+   */
+  jaws.unpack = function() {
+    var make_global = ["Sprite", "SpriteList", "Animation", "Viewport", "SpriteSheet", "Parallax", "TileMap", "pressed", "QuadTree"];
 
-/**
- * Logs <b>msg</b> to previously found or created <div id="jaws-log">
- * if <b>append</b> is true, append rather than overwrite the last log-msg.
- */
-jaws.log = function(msg, append) {
-  if(log_tag) {
-    msg += "<br />"
-    if(append) { log_tag.innerHTML = log_tag.innerHTML.toString() + msg } 
-    else { log_tag.innerHTML = msg }
+    make_global.forEach(function(item) {
+      if (window[item]) {
+        jaws.log("jaws.unpack: " + item + " already exists in global namespace.");
+      }
+      else {
+        window[item] = jaws[item];
+      }
+    });
+  };
+
+  /**
+   * Writes messages to either log_tag (if set) or console.log (if available)
+   * @param   {string}  msg     The string to write
+   * @param   {boolean} append  If messages should be appended or not
+   */
+  jaws.log = function(msg, append) {
+    if (!jaws.isString(msg)) {
+      msg = JSON.stringify(msg);
+    } 
+
+    if (log_tag && jaws.log.useLogElement) {
+      if (append) {
+        log_tag.innerHTML += msg + "<br />";
+      }
+      else {
+        log_tag.innerHTML = msg;
+      }
+    }
+    if(console.log && jaws.log.useConsole) {
+      console.log("JawsJS: " + msg);
+    }
+  };
+  
+  jaws.log.useConsole = false;
+  jaws.log.useLogElement = true;
+  /**
+   * Clears the contents of log_tag element (if set)
+   */
+  jaws.log.clear = function() {
+    if(log_tag) {
+      log_tag.innerHTML = "";
+    }
+  };
+
+  /**
+   * Initalizes jaws{canvas, context, dom, width, height}
+   * @private
+   * @param    {object}    options     Object-literal of constructor properties
+   * @see jaws.url_parameters()
+   */
+  jaws.init = function(options) {
+
+    var width = options.width || 500;
+    var height = options.height || 300;
+
+    /* Find <title> tag */
+    title = document.getElementsByTagName('title')[0];
+    jaws.url_parameters = jaws.getUrlParameters();
+
+    /*
+     * If debug=1 parameter is present in the URL, let's either find <div id="jaws-log"> or create the tag.
+     * jaws.log(message) will use this div for debug/info output to the gamer or developer
+     *
+     */
+    log_tag = document.getElementById('jaws-log');
+    if (jaws.url_parameters["debug"]) {
+      if (!log_tag) {
+        log_tag = document.createElement("div");
+        log_tag.id = "jaws-log";
+        log_tag.style.cssText = "overflow: auto; color: #aaaaaa; width: 300px; height: 150px; margin: 40px auto 0px auto; padding: 5px; border: #444444 1px solid; clear: both; font: 10px verdana; text-align: left;";
+        document.body.appendChild(log_tag);
+      }
+    }
+
+    jaws.canvas = document.getElementsByTagName('canvas')[0];
+    if (!jaws.canvas) {
+      jaws.dom = document.getElementById("canvas");
+    }
+
+    // Ordinary <canvas>, get context
+    if (jaws.canvas) {
+      jaws.context = jaws.canvas.getContext('2d');
+    } else if (jaws.dom) {
+      jaws.dom.style.position = "relative";
+    } else {
+      jaws.canvas = document.createElement("canvas");
+      jaws.canvas.width = width;
+      jaws.canvas.height = height;
+      jaws.context = jaws.canvas.getContext('2d');
+      document.body.appendChild(jaws.canvas);
+    }
+
+    /* Let's scale sprites retro-style by default */
+    if (jaws.context)
+      jaws.useCrispScaling();
+
+    jaws.width = jaws.canvas ? jaws.canvas.width : jaws.dom.offsetWidth;
+    jaws.height = jaws.canvas ? jaws.canvas.height : jaws.dom.offsetHeight;
+
+    jaws.mouse_x = 0;
+    jaws.mouse_y = 0;
+    window.addEventListener("mousemove", saveMousePosition);
+  };
+
+  /**
+   * Use 'retro' crisp scaling when drawing sprites through the canvas API, this is the default
+   */
+  jaws.useCrispScaling = function() {
+    jaws.context.imageSmoothingEnabled = false;
+    jaws.context.webkitImageSmoothingEnabled = false;
+    jaws.context.mozImageSmoothingEnabled = false;
+  };
+
+  /**
+   * Use smooth antialiased scaling when drawing sprites through the canvas API
+   */
+  jaws.useSmoothScaling = function() {
+    jaws.context.imageSmoothingEnabled = true;
+    jaws.context.webkitImageSmoothingEnabled = true;
+    jaws.context.mozImageSmoothingEnabled = true;
+  };
+
+  /**
+   * Keeps updated mouse coordinates in jaws.mouse_x and jaws.mouse_y
+   * This is called each time event "mousemove" triggers.
+   * @private
+   * @param {EventObject} e The EventObject populated by the calling event
+   */
+  function saveMousePosition(e) {
+    jaws.mouse_x = (e.pageX || e.clientX);
+    jaws.mouse_y = (e.pageY || e.clientY);
+
+    var game_area = jaws.canvas ? jaws.canvas : jaws.dom;
+    jaws.mouse_x -= game_area.offsetLeft;
+    jaws.mouse_y -= game_area.offsetTop;
   }
-}
 
-
-/**
- * @example
- * Initializes / creates:
- * jaws.canvas, jaws.context & jaws.dom   // our drawable gamearea
- * jaws.width & jaws.height               // width/height of drawable gamearea
- * jaws.url_parameters                    // hash of key/values of all parameters in current url
- * title & log_tag                        // used internally by jaws
- *
- * @private
- */
-jaws.init = function(options) {
-  /* Find <title> tag */
-  title = document.getElementsByTagName('title')[0]
-  jaws.url_parameters = jaws.getUrlParameters()
-
-  /*
-   * If debug=1 parameter is present in the URL, let's either find <div id="jaws-log"> or create the tag.
-   * jaws.log(message) will use this div for debug/info output to the gamer or developer
+  /**
+   * 1) Calls jaws.init(), detects or creats a canvas, and sets up the 2D context (jaws.canvas and jaws.context).
+   * 2) Pre-loads all defined assets with jaws.assets.loadAll().
+   * 3) Creates an instance of game_state and calls setup() on that instance.
+   * 4) Loops calls to update() and draw() with given FPS until game ends or another game state is activated.
+   * @param   {function}   game_state                The game state function to be started
+   * @param   {object}     options                   Object-literal of game loop properties
+   * @param   {object}     game_state_setup_options  Object-literal of game state properties and values
+   * @see jaws.init()
+   * @see jaws.setupInput()
+   * @see jaws.assets.loadAll()
+   * @see jaws.switchGameState()
+   * @example
+   *
+   *  jaws.start(MyGame)            // Start game state Game() with default options
+   *  jaws.start(MyGame, {fps: 30}) // Start game state Game() with options, in this case jaws will run your game with 30 frames per second.
+   *  jaws.start(window)            // Use global functions setup(), update() and draw() if available. Not the recommended way but useful for testing and mini-games.
    *
    */
-  log_tag = document.getElementById('jaws-log')
-  if(jaws.url_parameters["debug"]) {
-    if(!log_tag) {
-      log_tag = document.createElement("div")
-      log_tag.id = "jaws-log"
-      log_tag.style.cssText = "overflow: auto; color: #aaaaaa; width: 300px; height: 150px; margin: 40px auto 0px auto; padding: 5px; border: #444444 1px solid; clear: both; font: 10px verdana; text-align: left;"
-      document.body.appendChild(log_tag)
+  jaws.start = function(game_state, options, game_state_setup_options) {
+
+    if (!jaws.isFunction(game_state)) {
+      jaws.log("jaws.start: Passed in GameState is not a function.");
+      return;
     }
-  }
-
-  jaws.canvas = document.getElementsByTagName('canvas')[0]
-  if(!jaws.canvas) { jaws.dom = document.getElementById("canvas") }
-
-  // Ordinary <canvas>, get context
-  if(jaws.canvas) { jaws.context = jaws.canvas.getContext('2d'); }
-
-  // div-canvas / hml5 sprites, set position relative to have sprites with position = "absolute" stay within the canvas
-  else if(jaws.dom) { jaws.dom.style.position = "relative"; }  
-
-  // Niether <canvas> or <div>, create a <canvas> with specified or default width/height
-  else {
-    jaws.canvas = document.createElement("canvas")
-    jaws.canvas.width = options.width
-    jaws.canvas.height = options.height
-    jaws.context = jaws.canvas.getContext('2d')
-    document.body.appendChild(jaws.canvas)
-  }
-
-  /* Let's scale sprites retro-style by default */
-  jaws.useCrispScaling()
- 
-  jaws.width = jaws.canvas ? jaws.canvas.width : jaws.dom.offsetWidth
-  jaws.height = jaws.canvas ? jaws.canvas.height  : jaws.dom.offsetHeight
-
-  jaws.mouse_x = 0
-  jaws.mouse_y = 0
-  window.addEventListener("mousemove", saveMousePosition)
-}
-/**
- * Use 'retro' crisp scaling when drawing sprites through the canvas API, this is the default
- */
-jaws.useCrispScaling = function() {
-  jaws.context.imageSmoothingEnabled = false
-  jaws.context.webkitImageSmoothingEnabled = false
-  jaws.context.mozImageSmoothingEnabled = false 
-}
-
-/**
- * Use smooth antialiased scaling when drawing sprites through the canvas API
- */
-jaws.useSmoothScaling = function() {
-  jaws.context.imageSmoothingEnabled = true
-  jaws.context.webkitImageSmoothingEnabled = true
-  jaws.context.mozImageSmoothingEnabled = true
-}
-
-
-/**
- * @private
- * Keeps updated mouse coordinates in jaws.mouse_x / jaws.mouse_y
- * This is called each time event "mousemove" triggers.
- */
-function saveMousePosition(e) {
-  jaws.mouse_x = (e.pageX || e.clientX)
-  jaws.mouse_y = (e.pageY || e.clientY)
-  
-  var game_area = jaws.canvas ? jaws.canvas : jaws.dom
-  jaws.mouse_x -= game_area.offsetLeft
-  jaws.mouse_y -= game_area.offsetTop
-}
-
-/** 
- * Quick and easy startup of a jaws game loop. 
- *
- * @example
- *
- *  // jaws.start(YourGameState) It will do the following:
- *  //
- *  // 1) Call jaws.init() that will detect any canvas-tag (or create one for you) and set up the 2D context, then available in jaws.canvas and jaws.context.
- *  //
- *  // 2) Pre-load all defined assets with jaws.assets.loadAll() while showing progress, then available in jaws.assets.get("your_asset.png").
- *  //
- *  // 3) Create an instance of YourGameState() and call setup() on that instance. In setup() you usually create your gameobjects, sprites and so on.
- *  // 
- *  // 4) Loop calls to update() and draw() with given FPS (default 60) until game ends or another game state is activated.
- *
- *
- *  jaws.start(MyGame)            // Start game state Game() with default options
- *  jaws.start(MyGame, {fps: 30}) // Start game state Geme() with options, in this case jaws will run your game with 30 frames per second.
- *  jaws.start(window)            // Use global functions setup(), update() and draw() if available. Not the recommended way but useful for testing and mini-games.
- *
- *  // It's recommended not giving fps-option to jaws.start since then it will default to 60 FPS and using requestAnimationFrame when possible.
- *
- */
-jaws.start = function(game_state, options,game_state_setup_options) {
-  if(!options) options = {};
-  var fps = options.fps || 60
-  if(options.loading_screen === undefined)  options.loading_screen = true;
-  if(!options.width)                        options.width = 500; 
-  if(!options.height)                       options.height = 300;
-  jaws.init(options)
-
-  if(options.loading_screen) { jaws.assets.displayProgress(0) }
-
-  jaws.log("setupInput()", true)
-  jaws.setupInput()
-
-  /* Callback for when one single assets has been loaded */
-  function assetLoaded(src, percent_done) {
-    jaws.log(percent_done + "%: " + src, true)
-    if(options.loading_screen) { jaws.assets.displayProgress(percent_done) }
-  }
-
-  /* Callback for when an asset can't be loaded*/
-  function assetError(src) {
-    jaws.log( "Error loading: " + src, true)
-  }
-
-  /* Callback for when all assets are loaded */
-  function assetsLoaded() {
-    jaws.log("all assets loaded", true)
-    jaws.switchGameState(game_state||window, {fps: fps}, game_state_setup_options)
-  }
-
-  jaws.log("assets.loadAll()", true)
-  if(jaws.assets.length() > 0)  { jaws.assets.loadAll({onload:assetLoaded, onerror:assetError, onfinish:assetsLoaded}) }
-  else                          { assetsLoaded() } 
-}
-
-/**
-* Switch to a new active game state
-* Save previous game state in jaws.previous_game_state
-*
-* @example
-* 
-* function MenuState() {
-*   this.setup = function() { ... }
-*   this.draw = function() { ... }
-*   this.update = function() {
-*     if(pressed("enter")) jaws.switchGameState(GameState); // Start game when Enter is pressed
-*   }
-* }
-*
-* function GameState() {
-*   this.setup = function() { ... }
-*   this.update = function() { ... }
-*   this.draw = function() { ... }
-* }
-*
-* jaws.start(MenuState)
-*
-*/
-jaws.switchGameState = function(game_state, options,game_state_setup_options) {
-  var fps = (options && options.fps) || (jaws.game_loop && jaws.game_loop.fps) || 60
-  
-  jaws.game_loop && jaws.game_loop.stop()
-  jaws.clearKeyCallbacks() // clear out all keyboard callbacks
-  if(jaws.isFunction(game_state)) { game_state = new game_state }
-  
-  jaws.previous_game_state = jaws.game_state
-  jaws.game_state = game_state
-  jaws.game_loop = new jaws.GameLoop(game_state, {fps: fps},game_state_setup_options)
-  jaws.game_loop.start()
-}
-
-/** 
- * Takes an image, returns a canvas-element containing that image.
- * Benchmarks has proven canvas to be faster to work with then images in certain browsers.
- * Returns: a canvas-element
- */
-jaws.imageToCanvas = function(image) {
-  var canvas = document.createElement("canvas")
-  canvas.src = image.src        // Make canvas look more like an image
-  canvas.width = image.width
-  canvas.height = image.height
-
-  var context = canvas.getContext("2d")
-  context.drawImage(image, 0, 0, image.width, image.height)
-  return canvas
-}
-
-/** 
- * Return obj as an array. An array is returned as is. This is useful when you want to iterate over an unknown variable.
- *
- * @example
- *
- *   jaws.forceArray(1)       // --> [1]
- *   jaws.forceArray([1,2])   // --> [1,2]
- *
- */
-jaws.forceArray = function(obj) {
-  return Array.isArray(obj) ? obj : [obj]
-}
-
-/** Clears screen (the canvas-element) through context.clearRect() */
-jaws.clear = function() {
-  jaws.context.clearRect(0,0,jaws.width,jaws.height)
-}
-
-/** Returns true if obj is an Image */
-jaws.isImage = function(obj)  { 
-  return Object.prototype.toString.call(obj) === "[object HTMLImageElement]" 
-}
-
-/** Returns true of obj is a Canvas-element */
-jaws.isCanvas = function(obj) { 
-  return Object.prototype.toString.call(obj) === "[object HTMLCanvasElement]" 
-}
-
-/** Returns true of obj is either an Image or a Canvas-element */
-jaws.isDrawable = function(obj) { 
-  return jaws.isImage(obj) || jaws.isCanvas(obj) 
-}
-
-/** Returns true if obj is a String */
-jaws.isString = function(obj) { 
-  return (typeof obj == 'string') 
-}
-
-/** Returns true if obj is an Array */
-jaws.isArray = function(obj)  { 
-  if(obj === undefined) return false;
-  return !(obj.constructor.toString().indexOf("Array") == -1) 
-}
-
-/** Returns true of obj is a Function */
-jaws.isFunction = function(obj) { 
-  return (Object.prototype.toString.call(obj) === "[object Function]") 
-}
-
-/**
- * Returns true if <b>item</b> is outside the canvas.
- * <b>item</b> needs to have the properties x, y, width & height
- */
-jaws.isOutsideCanvas = function(item) { 
-  return (item.x < 0 || item.y < 0 || item.x > jaws.width || item.y > jaws.height)
-}
-
-/**
- * Force <b>item</b> inside canvas by setting items x/y parameters
- * <b>item</b> needs to have the properties x, y, width & height
- */
-jaws.forceInsideCanvas = function(item) {
-  if(item.x < 0)              { item.x = 0  }
-  if(item.x > jaws.width)     { item.x = jaws.width }
-  if(item.y < 0)              { item.y = 0 }
-  if(item.y > jaws.height)    { item.y = jaws.height }
-}
-
-/**
- * Return a hash of url-parameters and their values
- *
- * @example
- *   // Given the current URL is <b>http://test.com/?debug=1&foo=bar</b>
- *   jaws.getUrlParameters() // --> {debug: 1, foo: bar}
- */
-jaws.getUrlParameters = function() {
-  var vars = [], hash;
-  var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-  for(var i = 0; i < hashes.length; i++) {
-    hash = hashes[i].split('=');
-    vars.push(hash[0]);
-    vars[hash[0]] = hash[1];
-  }
-  return vars;
-}
-/**
- * Check for bad options/catch typos and init object with defaults options.
- * Used in all major constructors like Sprite() and so on.
- */
-jaws.parseOptions = function(object, options, defaults) {
-  object["options"] = options;
-
-  for(option in options) {
-    if(defaults[option] === undefined) {
-      throw("Unsupported option '" + option + "' sent to constructor");
+    if(!jaws.isObject(game_state_setup_options) && game_state_setup_options !== undefined) {
+      jaws.log("jaws.start: The setup options for the game state is not an object.");
+      return;
     }
-  }
-  for(option in defaults) {
-    object[option] = (options[option] !== undefined) ? options[option] : defaults[option];
-  }
-};
 
-return jaws;
+    if (!options)
+      options = {};
+    var fps = options.fps || 60;
+    if (options.loading_screen === undefined)
+      options.loading_screen = true;
+    if (!options.width)
+      options.width = 500;
+    if (!options.height)
+      options.height = 300;
+    jaws.init(options);
+
+    if (options.loading_screen) {
+      jaws.assets.displayProgress(0);
+    }
+
+    jaws.log("setupInput()", true);
+    jaws.setupInput();
+
+    /* Callback for when one single asset has been loaded */
+    function assetLoaded(src, percent_done) {
+      jaws.log(percent_done + "%: " + src, true);
+      if (options.loading_screen) {
+        jaws.assets.displayProgress(percent_done);
+      }
+    }
+
+    /* Callback for when an asset can't be loaded*/
+    function assetError(src, percent_done) {
+      jaws.log(percent_done + "%: Error loading asset " + src, true);
+    }
+
+    /* Callback for when all assets are loaded */
+    function assetsLoaded() {
+      jaws.log("all assets loaded", true);
+      jaws.switchGameState(game_state || window, {fps: fps}, game_state_setup_options);
+    }
+
+    jaws.log("assets.loadAll()", true);
+    if (jaws.assets.length() > 0) {
+      jaws.assets.loadAll({onload: assetLoaded, onerror: assetError, onfinish: assetsLoaded});
+    }
+    else {
+      assetsLoaded();
+    }
+  };
+
+  /**
+   * Switchs to a new active game state and saves previous game state in jaws.previous_game_state
+   * @param   {function}  game_state                The game state function to start
+   * @param   {object}    options                   The object-literal properties to pass to the new game loop
+   * @param   {object}    game_state_setup_options  The object-literal properties to pass to starting game state
+   * @example
+   * 
+   * function MenuState() {
+   *   this.setup = function() { ... }
+   *   this.draw = function() { ... }
+   *   this.update = function() {
+   *     if(pressed("enter")) jaws.switchGameState(GameState); // Start game when Enter is pressed
+   *   }
+   * }
+   *
+   * function GameState() {
+   *   this.setup = function() { ... }
+   *   this.update = function() { ... }
+   *   this.draw = function() { ... }
+   * }
+   *
+   * jaws.start(MenuState)
+   *
+   */
+  jaws.switchGameState = function(game_state, options, game_state_setup_options) {
+
+    if (!jaws.isFunction(game_state)) {
+      jaws.log("jaws.switchGameState: Passed in GameState is not a function.");
+      return;
+    }
+    
+    game_state = new game_state;
+    
+    if (!game_state.hasOwnProperty("setup")) {
+      jaws.log("jaws.switchGameState: GameState does not have a 'setup' property.");
+      return;
+    }
+    if (!game_state.hasOwnProperty("draw")) {
+      jaws.log("jaws.switchGameState: GameState does not have a 'draw' property.");
+      return;
+    }
+    if (!game_state.hasOwnProperty("update")) {
+      jaws.log("jaws.switchGameState: GameState does not have a 'update' property.");
+      return;
+    }
+
+    var fps = (options && options.fps) || (jaws.game_loop && jaws.game_loop.fps) || 60;
+
+    jaws.game_loop && jaws.game_loop.stop();
+    jaws.clearKeyCallbacks();
+
+    jaws.previous_game_state = jaws.game_state;
+    jaws.game_state = game_state;
+    jaws.game_loop = new jaws.GameLoop(game_state, {fps: fps}, game_state_setup_options);
+    jaws.game_loop.start();
+  };
+
+  /**
+   * Creates a new HTMLCanvasElement from a HTMLImageElement
+   * @param   {HTMLImageElement}  image   The HTMLImageElement to convert to a HTMLCanvasElement
+   * @returns {HTMLCanvasElement}         A HTMLCanvasElement with drawn HTMLImageElement content
+   */
+  jaws.imageToCanvas = function(image) {
+    
+    if(!jaws.isImage(image)) {
+      jaws.log("jaws.imageToCanvas: Passed in object is not an image.");
+      return;
+    }
+    
+    var canvas = document.createElement("canvas");
+    canvas.src = image.src;
+    canvas.width = image.width;
+    canvas.height = image.height;
+
+    var context = canvas.getContext("2d");
+    context.drawImage(image, 0, 0, image.width, image.height);
+    return canvas;
+  };
+
+  /**
+   * Returns object as an array
+   * @param   {object}  obj   An array or object
+   * @returns {array}         Either an array or the object as an array 
+   * @example
+   *
+   *   jaws.forceArray(1)       // --> [1]
+   *   jaws.forceArray([1,2])   // --> [1,2]
+   */
+  jaws.forceArray = function(obj) {
+    return Array.isArray(obj) ? obj : [obj];
+  };
+
+  /**
+   * Clears screen (the canvas-element) through context.clearRect()
+   */
+  jaws.clear = function() {
+    jaws.context.clearRect(0, 0, jaws.width, jaws.height);
+  };
+
+  /**
+   * Tests if object is an image or not
+   * @param   {object}  obj   An Image or image-like object
+   * @returns {boolean}       If object's prototype is "HTMLImageElement"
+   */
+  jaws.isImage = function(obj) {
+    return Object.prototype.toString.call(obj) === "[object HTMLImageElement]";
+  };
+
+  /**
+   * Tests if object is a Canvas object
+   * @param   {type}  obj   A canvas or canvas-like object
+   * @returns {boolean}     If object's prototype is "HTMLCanvasElement"
+   */
+  jaws.isCanvas = function(obj) {
+    return Object.prototype.toString.call(obj) === "[object HTMLCanvasElement]";
+  };
+
+  /**
+   * Tests if an object is either a canvas or an image object
+   * @param   {object}  obj   A canvas or canva-like object
+   * @returns {boolean}       If object isImage or isCanvas
+   */
+  jaws.isDrawable = function(obj) {
+    return jaws.isImage(obj) || jaws.isCanvas(obj);
+  };
+
+  /**
+   * Tests if an object is a string or not
+   * @param   {object}  obj   A string or string-like object
+   * @returns {boolean}       The result of typeof and constructor testing
+   */
+  jaws.isString = function(obj) {
+    return typeof obj === "string" || (typeof obj === "object" && obj.constructor === String);
+  };
+
+  /**
+   * Tests if an object is a number or not
+   * @param   {number}  n   A number or number-like value
+   * @returns {boolean}     If n passed isNaN() and isFinite()
+   */
+  jaws.isNumber = function(n) {
+    return !isNaN(parseFloat(n)) && isFinite(n);
+  };
+
+  /**
+   * Tests if an object is an Array or not
+   * @param   {object}  obj   An array or array-like object
+   * @returns {boolean}       If object's constructor is "Array"
+   */
+  jaws.isArray = function(obj) {
+    if (!obj)
+      return false;
+    return !(obj.constructor.toString().indexOf("Array") === -1);
+  };
+
+  /**
+   * Tests if an object is an Object or not
+   * @param   {object}  value   An object or object-like enitity
+   * @returns {boolean}         If object is not null and typeof 'object'
+   */
+  jaws.isObject = function(value) {
+    return value !== null && typeof value === 'object';
+  };
+
+  /**
+   * Tests if an object is a function or not
+   * @param   {object}  obj   A function or function-like object
+   * @returns {boolean}       If the prototype of the object is "Function"
+   */
+  jaws.isFunction = function(obj) {
+    return (Object.prototype.toString.call(obj) === "[object Function]");
+  };
+
+  /**
+   * Tests if an object is within drawing canvas (jaws.width and jaws.height) 
+   * @param   {object}  item  An object with both x and y properties
+   * @returns {boolean}       If the item's x and y are less than 0 or more than jaws.width or jaws.height
+   */
+  jaws.isOutsideCanvas = function(item) {
+    if (item.x && item.y) {
+      return (item.x < 0 || item.y < 0 || item.x > jaws.width || item.y > jaws.height);
+    }
+  };
+
+  /**
+   * Sets x and y properties to 0 (if less than), or jaws.width or jaws.height (if greater than)
+   * @param   {object}  item  An object with x and y properties
+   */
+  jaws.forceInsideCanvas = function(item) {
+    if (item.x && item.y) {
+      if (item.x < 0) {
+        item.x = 0;
+      }
+      if (item.x > jaws.width) {
+        item.x = jaws.width;
+      }
+      if (item.y < 0) {
+        item.y = 0;
+      }
+      if (item.y > jaws.height) {
+        item.y = jaws.height;
+      }
+    }
+  };
+
+  /**
+   * Parses current window.location for URL parameters and values
+   * @returns   {array}   Hash of url-parameters and their values
+   * @example
+   *   // Given the current URL is <b>http://test.com/?debug=1&foo=bar</b>
+   *   jaws.getUrlParameters() // --> {debug: 1, foo: bar}
+   */
+  jaws.getUrlParameters = function() {
+    var vars = [], hash;
+    var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+    for (var i = 0; i < hashes.length; i++) {
+      hash = hashes[i].split('=');
+      vars.push(hash[0]);
+      vars[hash[0]] = hash[1];
+    }
+    return vars;
+  };
+
+  /**
+   * Compares an object's default properties against those sent to its constructor
+   * @param   {object}  object    The object to compare and assign new values
+   * @param   {object}  options   Object-literal of constructor properties and new values
+   * @param   {object}  defaults  Object-literal of properties and their default values
+   */
+  jaws.parseOptions = function(object, options, defaults) {
+    object["options"] = options;
+
+    for (var option in options) {
+      if (defaults[option] === undefined) {
+        jaws.log("jaws.parseOptions: Unsupported property " + option + "for " + object.constructor);
+      }
+    }
+    for (var option in defaults) {
+      object[option] = (options[option] !== undefined) ? options[option] : jaws.clone(defaults[option]);
+    }
+  };
+
+  /**
+   * Returns a shallow copy of an array or object
+   * @param   {array|object}  value   The array or object to clone
+   * @returns {array|object}          A copy of an array of object
+   */
+  jaws.clone = function(value) {
+    if (jaws.isArray(value))
+      return value.slice(0);
+    if (jaws.isObject(value))
+      return JSON.parse(JSON.stringify(value));
+    return value;
+  };
+
+  return jaws;
 })(jaws || {});
 


### PR DESCRIPTION
Changes:

-- Added jaws.isNumber for checking if a value passes !isNaN and
isFinite tests.

-- Changed jaws.isString to detect String-like objects

-- jaws.parseOptions now logs an unsupported property instead of
throwing an error

-- "Rect" is no longer added to the window during a call to
jaws.unpack().
(Conflicts with pre-existing window.Rect reference in some browsers.)

-- "QuadTree" is now added to window during a call to jaws.unpack()

-- jaws.log.useConsole acts as flag for if logging should use the
console or not (default false)

-- jaws.log.useLogElement acts as flag for if logging should use the
log_tag element or not (default true)
