### PR TITLE
Sprite.js: Fix for colored rectangles

### DIFF
--- a/src/sprite.js
+++ b/src/sprite.js
@@ -82,9 +82,11 @@ jaws.Sprite.prototype.set = function(options) {
   if(!this.image && this.color && this.width && this.height) {
     var canvas = document.createElement('canvas');
     var context = canvas.getContext('2d');
+	canvas.width = this.width;
+	canvas.height = this.height;
     context.fillStyle = this.color;
     context.fillRect(0, 0, this.width, this.height);
-    this.image = context.getImageData(0, 0, this.width, this.height);
+    this.image = canvas;
   }
 
   this.cacheOffsets()


### PR DESCRIPTION
Here is the sprite.js fix to add back the correct functionality for
drawing colored rectangles instead of images.
