### PR TITLE
Text.js: Fixes, Docs

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -1,643 +1,694 @@
+/**
+ * @fileOverview A jaws.Text object with word-wrapping functionality.
+ * @class jaws.Text
+ * @property {integer}    x             Horizontal position  (0 = furthest left)
+ * @property {integer}    y             Vertical position    (0 = top)
+ * @property {number}     alpha         Transparency: 0 (fully transparent) to 1 (no transparency)
+ * @property {number}     angle         Angle in degrees (0-360)
+ * @property {string}     anchor        String stating how to anchor the sprite to canvas; @see Sprite#anchor
+ * @property {string}     text          The actual text to be displayed 
+ * @property {string}     fontFace      A valid font-family
+ * @property {number}     fontSize      The size of the text in pixels
+ * @property {string}     textAlign     "start", "end", "left", "right", or "center"
+ * @property {string}     textBaseline  "top", "bottom", "hanging", "middle", "alphabetic", or "ideographic"
+ * @property {number}     width         The width of the rect() containing the text
+ * @property {number}     height        The height of the rect() containing the text
+ * @property {string}     style         The style to draw the text: "normal", "bold" or italic"
+ * @property {boolean}    wordWrap      If word-wrapping should be attempted
+ * @property {string}     shadowColor   The color of the shadow for the text
+ * @property {number}     shadowBlur    The amount of shadow blur (length away from text)
+ * @property {number}     shadowOffsetX The start of the shadow from initial x
+ * @property {number}     shadowOffsetY The start of the shadow from initial y
+ * @example
+ *  var text = new Text({text: "Hello world!", x: 10, y: 10}) 
+ */
+
 var jaws = (function(jaws) {
 
-    /*
-     * @class A jaws.Text object with word-wrapping functionality.
-     * @constructor
-     *  
-     * @property {int} x     Horizontal position  (0 = furthest left)
-     * @property {int} y     Vertical position    (0 = top)
-     * @property {int} alpha     Transparency: 0 (fully transparent) to 1 (no transparency)
-     * @property {int} angle     Angle in degrees (0-360)
-     * @property {bool} flipped    Flip sprite horizontally, useful for sidescrollers
-     * @property {string} anchor   String stating how to anchor the sprite to canvas, @see Sprite#anchor ("top_left", "center" etc)
-     * @property {string} text       The actual text to be displayed 
-     * @property {string} fontFace   A valid font-family
-     * @property {int} fontSize      The size of the text in pixels
-     * @property {string} textAlign      "start", "end", "left", "right", or "center"
-     * @property {string} textBaseline       "top", "bottom", "hanging", "middle", "alphabetic", or "ideographic"
-     * @property {int} width     The width of the rect() containing the text
-     * @property {int} height    The height of the rect() containing the text
-     * @property {string} style     The style to draw the text: "normal", "bold" or italic"
-     * @property {bool} wordWrap     If true, will attempt to word-wrap text
-     *                               If false, will attempt to draw text within width
-     * @property {string} shadowColor   The color of the shadow for the text
-     * @property {int}  shadowBlur    The amount of shadow blur (length away from text)
-     * @property  {int} shadowOffsetX   The start of the shadow from initial x
-     * @property {int}  shadowOffsetY   The start of the shadow from initial y
-     *
-     * @example
-     * // create new Text at top left of the screen,
-     * new Text({text: "Hello world!", x: 0, y: 0, width: 500, height: 500, fontFace: "Terminal", fontSize: 50}) 
-     */
+  /**
+   * jaws.Text constructor
+   * @constructor
+   * @param {object} options An object-literal collection of constructor values
+   */
+  jaws.Text = function(options) {
+    if (!(this instanceof arguments.callee))
+      return new arguments.callee(options);
 
+    this.set(options);
 
-    jaws.Text = function(options) {
-        if (!(this instanceof arguments.callee))
-            return new arguments.callee(options);
+    if (options.context) {
+      this.context = options.context;
+    }
+    else if (options.dom) {  // No canvas context? Switch to DOM-based spritemode
+      this.dom = options.dom;
+      this.createDiv();
+    }
+    if (!options.context && !options.dom) { // Defaults to jaws.context or jaws.dom
+      if (jaws.context)
+        this.context = jaws.context;
+      else {
+        this.dom = jaws.dom;
+        this.createDiv();
+      }
+    }
+  };
 
-        this.set(options);
+  /**
+   * The default values of jaws.Text properties
+   */
+  jaws.Text.prototype.default_options = {
+    x: 0,
+    y: 0,
+    alpha: 1,
+    angle: 0,
+    anchor_x: 0,
+    anchor_y: 0,
+    anchor: "top_left",
+    damping: 1,
+    style: "normal",
+    fontFace: "serif",
+    fontSize: 12,
+    color: "black",
+    textAlign: "start",
+    textBaseline: "alphabetic",
+    text: "",
+    wordWrap: false,
+    width: jaws.width,
+    height: jaws.height,
+    shadowColor: null,
+    shadowBlur: null,
+    shadowOffsetX: null,
+    shadowOffsetY: null,
+    _constructor: null,
+    dom: null
+  };
 
-        if (options.context) {
-            this.context = options.context;
-        }
-        else if (options.dom) {  // No canvas context? Switch to DOM-based spritemode
-            this.dom = options.dom;
-            this.createDiv();
-        }
-        if (!options.context && !options.dom) { // Defaults to jaws.context or jaws.dom
-            if (jaws.context)
-                this.context = jaws.context;
-            else {
-                this.dom = jaws.dom;
-                this.createDiv();
-            }
-        }
-    };
+  /**
+   * Overrides constructor values with defaults
+   * @this {jaws.Text}
+   * @param {object} options An object-literal collection of constructor values
+   * @returns {this}
+   * @see jaws.parseOptions
+   */
+  jaws.Text.prototype.set = function(options) {
 
-    jaws.Text.prototype.default_options = {
-        x: 0,
-        y: 0,
-        alpha: 1,
-        angle: 0,
-        anchor_x: 0,
-        anchor_y: 0,
-        anchor: null,
-        damping: 1,
-        scale_x: 1,
-        scale_y: 1,
-        scale: 1,
-        style: "",
-        fontFace: "",
-        fontSize: 12,
-        color: "",
-        textAlign: "",
-        textBaseline: "",
-        text: "",
-        wordWrap: false,
-        width: 0,
-        height: 0,
-        shadowColor: null,
-        shadowBlur: null,
-        shadowOffsetX: null,
-        shadowOffsetY: null,
-        _constructor: null,
-        dom: null
-    };
+    jaws.parseOptions(this, options, this.default_options);
 
-    /** 
-     * @private
-     * Call setters from JSON object. Used to parse options.
-     */
-    jaws.Text.prototype.set = function(options) {
+    if (this.anchor)
+      this.setAnchor(this.anchor);
 
-        jaws.parseOptions(this, options, this.default_options);
+    this.cacheOffsets();
 
-        if (this.scale)
-            this.scale_x = this.scale_y = this.scale;
+    return this;
+  };
 
-        if (this.anchor)
-            this.setAnchor(this.anchor);
+  /**
+   * Returns a new instance based on the current jaws.Text object
+   * @private
+   * @this {jaws.Text}
+   * @returns {object} The newly cloned object
+   */
+  jaws.Text.prototype.clone = function() {
+    var constructor = this._constructor ? eval(this._constructor) : this.constructor;
+    var new_sprite = new constructor(this.attributes());
+    new_sprite._constructor = this._constructor || this.constructor.name;
+    return new_sprite;
+  };
 
-        this.text = options.text || "";
-        this.fontFace = options.fontFace || "serif";
-        this.fontSize = options.fontSize || 25;
-        this.color = options.color || "black";
-        this.textAlign = options.textAlign || "start";
-        this.textBaseline = options.textBaseline || "alphabetic";
-        this.style = options.style || "normal";
-        this.wordWrap = options.wordWrap || false;
-        this.width = options.width || jaws.width;
-        this.height = options.height || jaws.height;
+  /**
+   * Rotate sprite by value degrees
+   * @this {jaws.Text}
+   * @param {number} value The amount of the rotation
+   * @returns {this} Current function scope
+   */
+  jaws.Text.prototype.rotate = function(value) {
+    this.angle += value;
+    return this;
+  };
 
-        this.cacheOffsets();
+  /**
+   * Forces a rotation-angle on sprite
+   * @this {jaws.Text}
+   * @param {number} value The amount of the rotation
+   * @returns {this} Current function instance
+   */
+  jaws.Text.prototype.rotateTo = function(value) {
+    this.angle = value;
+    return this;
+  };
 
-        return this;
-    };
+  /**
+   * Move object to position x, y
+   * @this {jaws.Text}
+   * @param {number} x The x position to move to
+   * @param {number} y The y position to move to
+   * @returns {this} Current function instance
+   */
+  jaws.Text.prototype.moveTo = function(x, y) {
+    this.x = x;
+    this.y = y;
+    return this;
+  };
 
-    /** 
-     * @private
-     *
-     * Creates a new sprite from current sprites attributes()
-     * Checks JawsJS magic property '_constructor' when deciding with which constructor to create it
-     *
-     */
-    jaws.Text.prototype.clone = function(object) {
-        var constructor = this._constructor ? eval(this._constructor) : this.constructor;
-        var new_sprite = new constructor(this.attributes());
-        new_sprite._constructor = this._constructor || this.constructor.name;
-        return new_sprite;
-    };
+  /**
+   * Modify x and/or y by a fixed amount
+   * @this {jaws.Text}
+   * @param {type} x The additional amount to move x
+   * @param {type} y The additional amount to move y
+   * @returns {this} Current function instance
+   */
+  jaws.Text.prototype.move = function(x, y) {
+    if (x)
+      this.x += x;
+    if (y)
+      this.y += y;
+    return this;
+  };
 
-    /** Rotate sprite by value degrees */
-    jaws.Text.prototype.rotate = function(value) {
-        this.angle += value;
-        return this;
-    };
-    /** Force an rotation-angle on sprite */
-    jaws.Text.prototype.rotateTo = function(value) {
-        this.angle = value;
-        return this;
-    };
-    /** Set x/y */
-    jaws.Text.prototype.moveTo = function(x, y) {
-        this.x = x;
-        this.y = y;
-        return this;
-    };
-    /** Modify x/y */
-    jaws.Text.prototype.move = function(x, y) {
-        if (x)
-            this.x += x;
-        if (y)
-            this.y += y;
-        return this;
-    };
-    /** 
-     * scale sprite by given factor. 1=don't scale. <1 = scale down.  1>: scale up.
-     * Modifies width/height. 
-     **/
-    jaws.Text.prototype.scaleAll = function(value) {
-        this.scale_x *= value;
-        this.scale_y *= value;
-        this.fontSize *= value;
-        return this.cacheOffsets();
-    };
-    /** set scale factor. ie. 2 means a doubling if sprite in both directions. */
-    jaws.Text.prototype.scaleTo = function(value) {
-        this.scale_x = this.scale_y = value;
-        this.fontSize *= value;
-        return this.cacheOffsets();
-    };
-    /** scale sprite horizontally by scale_factor. Modifies width. */
-    jaws.Text.prototype.scaleWidth = function(value) {
-        this.scale_x *= value;
-        this.fontSize *= value;
-        return this.cacheOffsets();
-    };
-    /** scale sprite vertically by scale_factor. Modifies height. */
-    jaws.Text.prototype.scaleHeight = function(value) {
-        this.scale_y *= value;
-        this.fontSize *= value;
-        return this.cacheOffsets();
-    };
+  /**
+   * Sets x
+   * @param {number} value The new x value
+   * @returns {this} The current function instance
+   */
+  jaws.Text.prototype.setX = function(value) {
+    this.x = value;
+    return this;
+  };
 
-    /** Sets x */
-    jaws.Text.prototype.setX = function(value) {
-        this.x = value;
-        return this;
-    };
-    /** Sets y */
-    jaws.Text.prototype.setY = function(value) {
-        this.y = value;
-        return this;
-    };
+  /**
+   * Sets y
+   * @param {number} value The new y value
+   * @returns {this} The current function instance
+   */
+  jaws.Text.prototype.setY = function(value) {
+    this.y = value;
+    return this;
+  };
 
-    /** Position sprites top on the y-axis */
-    jaws.Text.prototype.setTop = function(value) {
-        this.y = value + this.top_offset;
-        return this;
-    };
-    /** Position sprites bottom on the y-axis */
-    jaws.Text.prototype.setBottom = function(value) {
-        this.y = value - this.bottom_offset;
-        return this;
-    };
-    /** Position sprites left side on the x-axis */
-    jaws.Text.prototype.setLeft = function(value) {
-        this.x = value + this.left_offset;
-        return this;
-    };
-    /** Position sprites right side on the x-axis */
-    jaws.Text.prototype.setRight = function(value) {
-        this.x = value - this.right_offset;
-        return this;
-    };
+  /**
+   * Position sprites top on the y-axis
+   * @param {number} value
+   * @returns {this} The current function instance
+   */
+  jaws.Text.prototype.setTop = function(value) {
+    this.y = value + this.top_offset;
+    return this;
+  };
 
-    /** Set new width. Scales sprite. */
-    jaws.Text.prototype.setWidth = function(value) {
-        this.scale_x = value / this.width;
-        return this.cacheOffsets();
-    };
-    /** Set new height. Scales sprite. */
-    jaws.Text.prototype.setHeight = function(value) {
-        this.scale_y = value / this.height;
-        return this.cacheOffsets();
-    };
-    /** Resize sprite by adding width */
-    jaws.Text.prototype.resize = function(width, height) {
-        this.scale_x = (this.width + width) / this.width;
-        this.scale_y = (this.height + height) / this.height;
-        return this.cacheOffsets();
-    };
-    /** 
-     * Resize sprite to exact width/height 
-     */
-    jaws.Text.prototype.resizeTo = function(width, height) {
-        this.scale_x = width / this.width;
-        this.scale_y = height / this.height;
-        return this.cacheOffsets();
-    };
+  /**
+   * Position sprites bottom on the y-axis
+   * @param {number} value
+   * @returns {this} The current function instance
+   */
+  jaws.Text.prototype.setBottom = function(value) {
+    this.y = value - this.bottom_offset;
+    return this;
+  };
 
-    /**
-     * The sprites anchor could be describe as "the part of the sprite will be placed at x/y"
-     * or "when rotating, what point of the of the sprite will it rotate round"
-     *
-     * @example
-     * For example, a topdown shooter could use setAnchor("center") --> Place middle of the ship on x/y
-     * .. and a sidescroller would probably use setAnchor("center_bottom") --> Place "feet" at x/y
-     */
-    jaws.Text.prototype.setAnchor = function(value) {
-        var anchors = {
-            top_left: [0, 0],
-            left_top: [0, 0],
-            center_left: [0, 0.5],
-            left_center: [0, 0.5],
-            bottom_left: [0, 1],
-            left_bottom: [0, 1],
-            top_center: [0.5, 0],
-            center_top: [0.5, 0],
-            center_center: [0.5, 0.5],
-            center: [0.5, 0.5],
-            bottom_center: [0.5, 1],
-            center_bottom: [0.5, 1],
-            top_right: [1, 0],
-            right_top: [1, 0],
-            center_right: [1, 0.5],
-            right_center: [1, 0.5],
-            bottom_right: [1, 1],
-            right_bottom: [1, 1]
-        };
+  /**
+   * Position sprites left side on the x-axis
+   * @param {number} value
+   * @returns {this} The current function instance
+   */
+  jaws.Text.prototype.setLeft = function(value) {
+    this.x = value + this.left_offset;
+    return this;
+  };
 
-        if (a = anchors[value]) {
-            this.anchor_x = a[0];
-            this.anchor_y = a[1];
-        }
-        return this;
-    };
+  /**
+   * Position sprites right side on the x-axis
+   * @param {number} value
+   * @returns {this} The current function instance
+   */
+  jaws.Text.prototype.setRight = function(value) {
+    this.x = value - this.right_offset;
+    return this;
+  };
 
-    /** @private */
-    jaws.Text.prototype.cacheOffsets = function() {
+  /**
+   * Set new width.
+   * @param {number} value The new width
+   * @returns {jaws.Rect}
+   */
+  jaws.Text.prototype.setWidth = function(value) {
+    this.width = value;
+    return this.cacheOffsets();
+  };
 
-        this.width = this.width * this.scale_x;
-        this.height = this.height * this.scale_y;
-        this.left_offset = this.width * this.anchor_x;
-        this.top_offset = this.height * this.anchor_y;
-        this.right_offset = this.width * (1.0 - this.anchor_x);
-        this.bottom_offset = this.height * (1.0 - this.anchor_y);
+  /**
+   * Set new height. 
+   * @param {number} value The new height
+   * @returns {jaws.Rect}
+   */
+  jaws.Text.prototype.setHeight = function(value) {
+    this.height = value;
+    return this.cacheOffsets();
+  };
 
-        if (this.cached_rect)
-            this.cached_rect.resizeTo(this.width, this.height);
-        return this;
+  /**
+   * Resize sprite by adding width or height
+   * @param {number} width
+   * @param {number} height
+   * @returns {jaws.Rect}
+   */
+  jaws.Text.prototype.resize = function(width, height) {
+    this.width += width;
+    this.height += height;
+    return this.cacheOffsets();
+  };
+
+  /**
+   * Resize sprite to exact width/height
+   * @this {jaws.Text}
+   * @param {number} width
+   * @param {number} height
+   * @returns {jaws.Rect}
+   */
+  jaws.Text.prototype.resizeTo = function(width, height) {
+    this.width = width;
+    this.height = height;
+    return this.cacheOffsets();
+  };
+
+  /**
+   * The anchor could be describe as "the part of the text will be placed at x/y"
+   * or "when rotating, what point of the of the text will it rotate round"
+   * @param {string} value
+   * @returns {this} The current function instance
+   * @example
+   * For example, a topdown shooter could use setAnchor("center") --> Place middle of the ship on x/y
+   * .. and a sidescroller would probably use setAnchor("center_bottom") --> Place "feet" at x/y
+   */
+  jaws.Text.prototype.setAnchor = function(value) {
+    var anchors = {
+      top_left: [0, 0],
+      left_top: [0, 0],
+      center_left: [0, 0.5],
+      left_center: [0, 0.5],
+      bottom_left: [0, 1],
+      left_bottom: [0, 1],
+      top_center: [0.5, 0],
+      center_top: [0.5, 0],
+      center_center: [0.5, 0.5],
+      center: [0.5, 0.5],
+      bottom_center: [0.5, 1],
+      center_bottom: [0.5, 1],
+      top_right: [1, 0],
+      right_top: [1, 0],
+      center_right: [1, 0.5],
+      right_center: [1, 0.5],
+      bottom_right: [1, 1],
+      right_bottom: [1, 1]
     };
 
-    /** Returns a jaws.Rect() perfectly surrouning sprite. Also cache rect in this.cached_rect. */
-    jaws.Text.prototype.rect = function() {
-        if (!this.cached_rect && this.width)
-            this.cached_rect = new jaws.Rect(this.x, this.y, this.width, this.height);
-        if (this.cached_rect)
-            this.cached_rect.moveTo(this.x - this.left_offset, this.y - this.top_offset);
-        return this.cached_rect;
+    if (anchors.hasOwnProperty(value)) {
+      this.anchor_x = anchors[value][0];
+      this.anchor_y = anchors[value][1];
+      this.cacheOffsets();
+    }
+    return this;
+  };
+
+  /**
+   * Save the object's dimensions
+   * @private
+   * @returns {this} The current function instance
+   */
+  jaws.Text.prototype.cacheOffsets = function() {
+
+    this.left_offset = this.width * this.anchor_x;
+    this.top_offset = this.height * this.anchor_y;
+    this.right_offset = this.width * (1.0 - this.anchor_x);
+    this.bottom_offset = this.height * (1.0 - this.anchor_y);
+
+    if (this.cached_rect)
+      this.cached_rect.resizeTo(this.width, this.height);
+    return this;
+  };
+
+  /**
+   * Returns a jaws.Rect() perfectly surrouning text.
+   * @returns {jaws.Rect}
+   */
+  jaws.Text.prototype.rect = function() {
+    if (!this.cached_rect && this.width)
+      this.cached_rect = new jaws.Rect(this.x, this.y, this.width, this.height);
+    if (this.cached_rect)
+      this.cached_rect.moveTo(this.x - this.left_offset, this.y - this.top_offset);
+    return this.cached_rect;
+  };
+
+  /**
+   * Make this sprite a DOM-based <div> sprite 
+   * @private
+   */
+  jaws.Text.prototype.createDiv = function() {
+    this.div = document.createElement("div");
+    this.div.style.position = "absolute";
+    this.div.style.width = this.width + "px";
+    this.div.style.height = this.height + "px";
+    this.div.style.fontSize = this.fontSize + "px";
+    this.div.style.fontFamily = this.fontFace;
+
+    this.div.style.textShadow = (this.shadowOffsetX || "0") + "px "
+            + (this.shadowOffsetY || "0") + "px " + (this.shadowBlur || "0")
+            + "px " + (this.shadowColor || "");
+
+    if (this.textAlign === "start")
+      this.div.style.textAlign = "left";
+    else if (this.textAlign === "end")
+      this.div.style.textAlign = "right";
+    else
+      this.div.style.textAlign = this.textAlign;
+
+    if (this.textBaseline === "top")
+      this.div.style.verticalAlign = "super";
+    else if (this.textBaseline === "hanging")
+      this.div.style.verticalAlign = "text-top";
+    else if (this.textBaseline === "alphabetic")
+      this.div.style.verticalAlign = "bottom";
+    else if (this.div.style.verticalAlign === "ideographic")
+      this.div.style.verticalAlign = "text-bottom";
+    else
+      this.div.style.verticalAlign = this.textBaseline;
+
+    if (this.div.innerText) {
+      this.div.innerText = this.text;
+    }
+    else {
+      this.div.textContent = this.text;
     }
 
-    /**
-     * Make this sprite a DOM-based <div> sprite 
-     * @private
-     */
-    jaws.Text.prototype.createDiv = function() {
-        this.div = document.createElement("div");
-        this.div.style.position = "absolute";
-        this.div.style.width = this.width + "px";
-        this.div.style.height = this.height + "px";
-        this.div.style.fontSize = this.fontSize + "px";
-        this.div.style.fontFamily = this.fontFace;
-        
-        this.div.style.textShadow = (this.shadowOffsetX || "0") + "px "
-          + (this.shadowOffsetY || "0") + "px " + (this.shadowBlur || "0")
-          + "px " + (this.shadowColor || "");
-        
-        if(this.textAlign === "start")
-            this.div.style.textAlign = "left";
-        else if(this.textAlign === "end")
-            this.div.style.textAlign = "right";
-        else
-            this.div.style.textAlign = this.textAlign;
-        
-        if(this.textBaseline === "top")
-            this.div.style.verticalAlign = "super";
-        else if(this.textBaseline === "hanging")
-            this.div.style.verticalAlign = "text-top";
-        else if(this.textBaseline === "alphabetic")
-            this.div.style.verticalAlign = "bottom";
-        else if(this.div.style.verticalAlign === "ideographic")
-            this.div.style.verticalAlign = "text-bottom";
-        else
-            this.div.style.verticalAlign = this.textBaseline;
-        
-        if (this.div.innerText) {
-            this.div.innerText = this.text;
-        }
-        else {
-            this.div.textContent = this.text;
-        }
+    if (this.dom) {
+      this.dom.appendChild(this.div);
+    }
 
-        if (this.dom) {
-            this.dom.appendChild(this.div);
-        }
+    this.updateDiv();
+  };
 
-        this.updateDiv();
-    };
+  /** 
+   * Update properties for DOM-based sprite
+   * @private
+   */
+  jaws.Text.prototype.updateDiv = function() {
+    this.div.style.left = this.x + "px";
+    this.div.style.top = this.y + "px";
 
-    /** 
-     * @private
-     * Update properties for DOM-based sprite 
-     */
-    jaws.Text.prototype.updateDiv = function() {
-        this.div.style.left = this.x + "px";
-        this.div.style.top = this.y + "px";
+    var transform = "";
+    transform += "rotate(" + this.angle + "deg) ";
 
-        var transform = "";
-        transform += "rotate(" + this.angle + "deg) ";
-        if (this.flipped) {
-            transform += "scale(-" + this.scale_x + "," + this.scale_y + ")";
-        }
-        else {
-            transform += "scale(" + this.scale_x + "," + this.scale_y + ")";
-        }
+    this.div.style.MozTransform = transform;
+    this.div.style.WebkitTransform = transform;
+    this.div.style.OTransform = transform;
+    this.div.style.msTransform = transform;
+    this.div.style.transform = transform;
 
-        this.div.style.MozTransform = transform;
-        this.div.style.WebkitTransform = transform;
-        this.div.style.OTransform = transform;
-        this.div.style.msTransform = transform;
-        this.div.style.transform = transform;
+    return this;
+  };
 
-        return this;
-    };
+  /**
+   * Draw sprite on active canvas or update its DOM-properties
+   * @this {jaws.Text}
+   * @returns {this} The current function instance
+   */
+  jaws.Text.prototype.draw = function() {
+    if (this.dom) {
+      return this.updateDiv();
+    }
+    this.context.save();
+    if (this.angle !== 0) {
+      this.context.rotate(this.angle * Math.PI / 180);
+    }
+    this.context.globalAlpha = this.alpha;
+    this.context.translate(-this.left_offset, -this.top_offset); // Needs to be separate from above translate call cause of flipped
+    this.context.fillStyle = this.color;
+    this.context.font = this.style + " " + this.fontSize + "px " + this.fontFace;
+    this.context.textBaseline = this.textBaseline;
+    this.context.textAlign = this.textAlign;
+    if (this.shadowColor)
+      this.context.shadowColor = this.shadowColor;
+    if (this.shadowBlur)
+      this.context.shadowBlur = this.shadowBlur;
+    if (this.shadowOffsetX)
+      this.context.shadowOffsetX = this.shadowOffsetX;
+    if (this.shadowOffsetY)
+      this.context.shadowOffsetY = this.shadowOffsetY;
+    var oldY = this.y;
+    var oldX = this.x;
+    if (this.wordWrap)
+    {
+      var words = this.text.split(' ');
+      var nextLine = '';
 
-    /** Draw sprite on active canvas or update it's DOM-properties */
-    jaws.Text.prototype.draw = function() {
-        if (this.dom) {
-            return this.updateDiv();
-        }
-        this.context.save();
-        if (this.angle !== 0) {
-            this.context.rotate(this.angle * Math.PI / 180);
-        }
-        this.flipped && this.context.scale(-1, 1);
-        this.context.globalAlpha = this.alpha;
-        this.context.translate(-this.left_offset, -this.top_offset); // Needs to be separate from above translate call cause of flipped
-        this.context.fillStyle = this.color;
-        this.context.font = this.style + " " + this.fontSize + "px " + this.fontFace;
-        this.context.textBaseline = this.textBaseline;
-        this.context.textAlign = this.textAlign;
-        if(this.shadowColor) this.context.shadowColor = this.shadowColor;
-        if(this.shadowBlur) this.context.shadowBlur = this.shadowBlur;
-        if(this.shadowOffsetX) this.context.shadowOffsetX = this.shadowOffsetX;
-        if(this.shadowOffsetY) this.context.shadowOffsetY = this.shadowOffsetY;
-        var oldY = this.y;
-        var oldX = this.x;
-        if (this.wordWrap)
+      for (var n = 0; n < words.length; n++)
+      {
+        var testLine = nextLine + words[n] + ' ';
+        var measurement = this.context.measureText(testLine);
+        if (this.y < oldY + this.height)
         {
-            var words = this.text.split(' ');
-            var nextLine = '';
-
-            for (var n = 0; n < words.length; n++)
-            {
-                var testLine = nextLine + words[n] + ' ';
-                var measurement = this.context.measureText(testLine);
-                if (this.y < oldY + this.height)
-                {
-                    if (measurement.width > this.width)
-                    {
-                        this.context.fillText(nextLine, this.x, this.y);
-                        nextLine = words[n] + ' ';
-                        this.y += this.fontSize;
-                    }
-                    else {
-                        nextLine = testLine;
-                    }
-                    this.context.fillText(nextLine, this.x, this.y);
-                }
-            }
+          if (measurement.width > this.width)
+          {
+            this.context.fillText(nextLine, this.x, this.y);
+            nextLine = words[n] + ' ';
+            this.y += this.fontSize;
+          }
+          else {
+            nextLine = testLine;
+          }
+          this.context.fillText(nextLine, this.x, this.y);
         }
-        else
+      }
+    }
+    else
+    {
+      if (this.context.measureText(this.text).width < this.width)
+      {
+        this.context.fillText(this.text, this.x, this.y);
+      }
+      else
+      {
+        var words = this.text.split(' ');
+        var nextLine = ' ';
+        for (var n = 0; n < words.length; n++)
         {
-            if (this.context.measureText(this.text).width < this.width)
-            {
-                this.context.fillText(this.text, this.x, this.y);
-            }
-            else
-            {
-                var words = this.text.split(' ');
-                var nextLine = ' ';
-                for (var n = 0; n < words.length; n++)
-                {
-                    var testLine = nextLine + words[n] + ' ';
-                    if (this.context.measureText(testLine).width < Math.abs(this.width - this.x))
-                    {
-                        this.context.fillText(testLine, this.x, this.y);
-                        nextLine = words[n] + ' ';
-                        nextLine = testLine;
-                    }
-                }
-            }
+          var testLine = nextLine + words[n] + ' ';
+          if (this.context.measureText(testLine).width < Math.abs(this.width - this.x))
+          {
+            this.context.fillText(testLine, this.x, this.y);
+            nextLine = words[n] + ' ';
+            nextLine = testLine;
+          }
         }
-        this.y = oldY;
-        this.x = oldX;
-        this.context.restore();
-        return this;
-    };
+      }
+    }
+    this.y = oldY;
+    this.x = oldX;
+    this.context.restore();
+    return this;
+  };
 
-    /** 
-     * Returns sprite as a canvas context.
-     * For certain browsers, a canvas context is faster to work with then a pure image.
-     */
-    jaws.Text.prototype.asCanvasContext = function() {
-        var canvas = document.createElement("canvas");
-        canvas.width = this.width;
-        canvas.height = this.height;
+  /** 
+   * Returns sprite as a canvas context.
+   * (For certain browsers, a canvas context is faster to work with then a pure image.)
+   * @public
+   * @this {jaws.Text}
+   */
+  jaws.Text.prototype.asCanvasContext = function() {
+    var canvas = document.createElement("canvas");
+    canvas.width = this.width;
+    canvas.height = this.height;
 
-        var context = canvas.getContext("2d");
-        context.mozImageSmoothingEnabled = jaws.context.mozImageSmoothingEnabled;
+    var context = canvas.getContext("2d");
+    context.mozImageSmoothingEnabled = jaws.context.mozImageSmoothingEnabled;
 
-        this.context.fillStyle = this.color;
-        this.context.font = this.style + this.fontSize + "px " + this.fontFace;
-        this.context.textBaseline = this.textBaseline;
-        this.context.textAlign = this.textAlign;
-        if(this.shadowColor) this.context.shadowColor = this.shadowColor;
-        if(this.shadowBlur) this.context.shadowBlur = this.shadowBlur;
-        if(this.shadowOffsetX) this.context.shadowOffsetX = this.shadowOffsetX;
-        if(this.shadowOffsetY) this.context.shadowOffsetY = this.shadowOffsetY;
-        var oldY = this.y;
-        var oldX = this.x;
-        if (this.wordWrap)
+    this.context.fillStyle = this.color;
+    this.context.font = this.style + this.fontSize + "px " + this.fontFace;
+    this.context.textBaseline = this.textBaseline;
+    this.context.textAlign = this.textAlign;
+    if (this.shadowColor)
+      this.context.shadowColor = this.shadowColor;
+    if (this.shadowBlur)
+      this.context.shadowBlur = this.shadowBlur;
+    if (this.shadowOffsetX)
+      this.context.shadowOffsetX = this.shadowOffsetX;
+    if (this.shadowOffsetY)
+      this.context.shadowOffsetY = this.shadowOffsetY;
+    var oldY = this.y;
+    var oldX = this.x;
+    if (this.wordWrap)
+    {
+      var words = this.text.split(' ');
+      var nextLine = '';
+
+      for (var n = 0; n < words.length; n++)
+      {
+        var testLine = nextLine + words[n] + ' ';
+        var measurement = this.context.measureText(testLine);
+        if (this.y < oldY + this.height)
         {
-            var words = this.text.split(' ');
-            var nextLine = '';
-
-            for (var n = 0; n < words.length; n++)
-            {
-                var testLine = nextLine + words[n] + ' ';
-                var measurement = this.context.measureText(testLine);
-                if (this.y < oldY + this.height)
-                {
-                    if (measurement.width > this.width)
-                    {
-                        this.context.fillText(nextLine, this.x, this.y);
-                        nextLine = words[n] + ' ';
-                        this.y += this.fontSize;
-                    }
-                    else {
-                        nextLine = testLine;
-                    }
-                    this.context.fillText(nextLine, this.x, this.y);
-                }
-            }
+          if (measurement.width > this.width)
+          {
+            this.context.fillText(nextLine, this.x, this.y);
+            nextLine = words[n] + ' ';
+            this.y += this.fontSize;
+          }
+          else {
+            nextLine = testLine;
+          }
+          this.context.fillText(nextLine, this.x, this.y);
         }
-        else
+      }
+    }
+    else
+    {
+      if (this.context.measureText(this.text).width < this.width)
+      {
+        this.context.fillText(this.text, this.x, this.y);
+      }
+      else
+      {
+        var words = this.text.split(' ');
+        var nextLine = ' ';
+        for (var n = 0; n < words.length; n++)
         {
-            if (this.context.measureText(this.text).width < this.width)
-            {
-                this.context.fillText(this.text, this.x, this.y);
-            }
-            else
-            {
-                var words = this.text.split(' ');
-                var nextLine = ' ';
-                for (var n = 0; n < words.length; n++)
-                {
-                    var testLine = nextLine + words[n] + ' ';
-                    if (this.context.measureText(testLine).width < Math.abs(this.width - this.x))
-                    {
-                        this.context.fillText(testLine, this.x, this.y);
-                        nextLine = words[n] + ' ';
-                        nextLine = testLine;
-                    }
-                }
-            }
+          var testLine = nextLine + words[n] + ' ';
+          if (this.context.measureText(testLine).width < Math.abs(this.width - this.x))
+          {
+            this.context.fillText(testLine, this.x, this.y);
+            nextLine = words[n] + ' ';
+            nextLine = testLine;
+          }
         }
-        this.y = oldY;
-        this.x = oldX;
-        return context;
-    };
+      }
+    }
+    this.y = oldY;
+    this.x = oldX;
+    return context;
+  };
 
-    /** 
-     * Returns sprite as a canvas
-     */
-    jaws.Text.prototype.asCanvas = function() {
-        var canvas = document.createElement("canvas");
-        canvas.width = this.width;
-        canvas.height = this.height;
+  /** 
+   * Returns text as a canvas
+   * @this {jaws.Text}
+   */
+  jaws.Text.prototype.asCanvas = function() {
+    var canvas = document.createElement("canvas");
+    canvas.width = this.width;
+    canvas.height = this.height;
 
-        var context = canvas.getContext("2d");
-        context.mozImageSmoothingEnabled = jaws.context.mozImageSmoothingEnabled;
+    var context = canvas.getContext("2d");
+    context.mozImageSmoothingEnabled = jaws.context.mozImageSmoothingEnabled;
 
-        this.context.fillStyle = this.color;
-        this.context.font = this.style + this.fontSize + "px " + this.fontFace;
-        this.context.textBaseline = this.textBaseline;
-        this.context.textAlign = this.textAlign;
-        if(this.shadowColor) this.context.shadowColor = this.shadowColor;
-        if(this.shadowBlur) this.context.shadowBlur = this.shadowBlur;
-        if(this.shadowOffsetX) this.context.shadowOffsetX = this.shadowOffsetX;
-        if(this.shadowOffsetY) this.context.shadowOffsetY = this.shadowOffsetY;
-        var oldY = this.y;
-        var oldX = this.x;
-        if (this.wordWrap)
+    this.context.fillStyle = this.color;
+    this.context.font = this.style + this.fontSize + "px " + this.fontFace;
+    this.context.textBaseline = this.textBaseline;
+    this.context.textAlign = this.textAlign;
+    if (this.shadowColor)
+      this.context.shadowColor = this.shadowColor;
+    if (this.shadowBlur)
+      this.context.shadowBlur = this.shadowBlur;
+    if (this.shadowOffsetX)
+      this.context.shadowOffsetX = this.shadowOffsetX;
+    if (this.shadowOffsetY)
+      this.context.shadowOffsetY = this.shadowOffsetY;
+    var oldY = this.y;
+    var oldX = this.x;
+    if (this.wordWrap)
+    {
+      var words = this.text.split(' ');
+      var nextLine = '';
+
+      for (var n = 0; n < words.length; n++)
+      {
+        var testLine = nextLine + words[n] + ' ';
+        var measurement = context.measureText(testLine);
+        if (this.y < oldY + this.height)
         {
-            var words = this.text.split(' ');
-            var nextLine = '';
-
-            for (var n = 0; n < words.length; n++)
-            {
-                var testLine = nextLine + words[n] + ' ';
-                var measurement = context.measureText(testLine);
-                if (this.y < oldY + this.height)
-                {
-                    if (measurement.width > this.width)
-                    {
-                        context.fillText(nextLine, this.x, this.y);
-                        nextLine = words[n] + ' ';
-                        this.y += this.fontSize;
-                    }
-                    else {
-                        nextLine = testLine;
-                    }
-                    context.fillText(nextLine, this.x, this.y);
-                }
-            }
+          if (measurement.width > this.width)
+          {
+            context.fillText(nextLine, this.x, this.y);
+            nextLine = words[n] + ' ';
+            this.y += this.fontSize;
+          }
+          else {
+            nextLine = testLine;
+          }
+          context.fillText(nextLine, this.x, this.y);
         }
-        else
+      }
+    }
+    else
+    {
+      if (context.measureText(this.text).width < this.width)
+      {
+        this.context.fillText(this.text, this.x, this.y);
+      }
+      else
+      {
+        var words = this.text.split(' ');
+        var nextLine = ' ';
+        for (var n = 0; n < words.length; n++)
         {
-            if (context.measureText(this.text).width < this.width)
-            {
-                this.context.fillText(this.text, this.x, this.y);
-            }
-            else
-            {
-                var words = this.text.split(' ');
-                var nextLine = ' ';
-                for (var n = 0; n < words.length; n++)
-                {
-                    var testLine = nextLine + words[n] + ' ';
-                    if (context.measureText(testLine).width < Math.abs(this.width - this.x))
-                    {
-                        context.fillText(testLine, this.x, this.y);
-                        nextLine = words[n] + ' ';
-                        nextLine = testLine;
-                    }
-                }
-            }
+          var testLine = nextLine + words[n] + ' ';
+          if (context.measureText(testLine).width < Math.abs(this.width - this.x))
+          {
+            context.fillText(testLine, this.x, this.y);
+            nextLine = words[n] + ' ';
+            nextLine = testLine;
+          }
         }
-        this.y = oldY;
-        this.x = oldX;
-        return canvas;
-    };
+      }
+    }
+    this.y = oldY;
+    this.x = oldX;
+    return canvas;
+  };
 
-    jaws.Text.prototype.toString = function() {
-        return "[Text " + this.x.toFixed(2) + ", " + this.y.toFixed(2) + ", " + this.width + ", " + this.height + "]";
-    };
+  /**
+   * Returns Text's properties as a String 
+   * @returns {string}
+   */
+  jaws.Text.prototype.toString = function() {
+    return "[Text " + this.x.toFixed(2) + ", " + this.y.toFixed(2) + ", " + this.width + ", " + this.height + "]";
+  };
 
-    /** returns Texts state/properties as a pure object */
-    jaws.Text.prototype.attributes = function() {
-        var object = this.options;                  // Start with all creation time properties
-        object["_constructor"] = this._constructor || "jaws.Text";
-        object["x"] = parseFloat(this.x.toFixed(2));
-        object["y"] = parseFloat(this.y.toFixed(2));
-        object["text"] = this.text;
-        object["alpha"] = this.alpha;
-        object["flipped"] = this.flipped;
-        object["angle"] = parseFloat(this.angle.toFixed(2));
-        object["scale_x"] = this.scale_x;
-        object["scale_y"] = this.scale_y;
-        object["anchor_x"] = this.anchor_x;
-        object["anchor_y"] = this.anchor_y;
-        object["style"] = this.style;
-        object["fontSize"] = this.fontSize;
-        object["fontFace"] = this.fontFace;
-        object["color"] = this.color;
-        object["textAlign"] = this.textAlign;
-        object["textBaseline"] = this.textBaseline;
-        object["wordWrap"] = this.wordWrap;
-        object["width"] = this.width;
-        object["height"] = this.height;
-        return object;
-    };
+  /**
+   * Returns Text's properties as a pure object
+   * @returns {object}
+   */
+  jaws.Text.prototype.attributes = function() {
+    var object = this.options;                  // Start with all creation time properties
+    object["_constructor"] = this._constructor || "jaws.Text";
+    object["x"] = parseFloat(this.x.toFixed(2));
+    object["y"] = parseFloat(this.y.toFixed(2));
+    object["text"] = this.text;
+    object["alpha"] = this.alpha;
+    object["angle"] = parseFloat(this.angle.toFixed(2));
+    object["anchor_x"] = this.anchor_x;
+    object["anchor_y"] = this.anchor_y;
+    object["style"] = this.style;
+    object["fontSize"] = this.fontSize;
+    object["fontFace"] = this.fontFace;
+    object["color"] = this.color;
+    object["textAlign"] = this.textAlign;
+    object["textBaseline"] = this.textBaseline;
+    object["wordWrap"] = this.wordWrap;
+    object["width"] = this.width;
+    object["height"] = this.height;
+    return object;
+  };
 
-    /**
-     * returns a JSON-string representing the state of the Text.
-     *
-     * Use this to serialize your sprites / game objects, maybe to save in local storage or on a server
-     *
-     * jaws.game_states.Edit uses this to export all edited objects.
-     *
-     */
-    jaws.Text.prototype.toJSON = function() {
-        return JSON.stringify(this.attributes())
-    };
+  /**
+   * Returns a JSON-string representing the properties of the Text.
+   * @returns {string}
+   */
+  jaws.Text.prototype.toJSON = function() {
+    return JSON.stringify(this.attributes());
+  };
 
-    return jaws;
+  return jaws;
 })(jaws || {});
 
 // Support CommonJS require()
 if (typeof module !== "undefined" && ('exports' in module)) {
-    module.exports = jaws.Text;
+  module.exports = jaws.Text;
 }

--- a/test/index.html
+++ b/test/index.html
@@ -25,8 +25,8 @@
   <script src="pixel_map_extra.js" type="text/javascript"></script>
   <script src="audio.js" type="text/javascript"></script>
   <script src="quadtree.js" type="text/javascript"></script>
-  <!--
   <script src="text.js" type="text/javascript"></script>
+  <!--
   <script src="parallax.js" type="text/javascript"></script>
   -->
 

--- a/test/text.js
+++ b/test/text.js
@@ -1,96 +1,76 @@
-module("Text")
+module("Text");
 
-test("text special options", function() {
-  text = new jaws.Text({dom: null, _constructor: "Troll"})
-  deepEqual(text.options["_constructor"], "Troll")
+test("Text special options", function() {
+  text = new jaws.Text({dom: null, _constructor: "Troll"});
+  deepEqual(text.options["_constructor"], "Troll");
 });
 
-test("Text defaults", function() {
-  text = new jaws.Text({});
+test("Text default values", function() {
+  var text = new jaws.Text({});
   deepEqual(text.x, 0, "x defaults to 0");
   deepEqual(text.y, 0, "y defaults to 0");
   deepEqual(text.angle, 0, "angle defaults to 0");
-  deepEqual(text.scale_x, 1, "scale_x defaults to 1 (no scaling)");
-  deepEqual(text.scale_y, 1, "scale_y defaults to 1 (no scaling)");
   deepEqual(text.anchor_x, 0, "anchor_x defaults to 0 (top)");
   deepEqual(text.anchor_y, 0, "anchor_y defaults to 0 (left)");
   deepEqual(text.text, "", "text defaults to empty string");
   deepEqual(text.alpha, 1, "alpha defalts to 1 (zero fading)");
   deepEqual(text.fontFace, "serif", "text.fontFace defaults to 'serif'");
-  deepEqual(text.fontSize, 25, "text.fontSize defaults to 25");
+  deepEqual(text.fontSize, 12, "text.fontSize defaults to 25");
   deepEqual(text.color, "black", "text.color defaults to 'black'");
-  deepEqual(text.textAlign, "left", "text.textAlign defaults to 'left'");
+  deepEqual(text.textAlign, "start", "text.textAlign defaults to 'start'");
   deepEqual(text.textBaseline, "alphabetic", "text.textBaseline defaults to 'alphabetic'");
   deepEqual(text.wordWrap, false, "text.wordWrap defaults to false");
-  deepEqual(text.style, "", "text.style defaults to empty string");
+  deepEqual(text.style, "normal", "text.style defaults to 'normal'");
 });
 
-test("text", function() {
+test("Text functionality", function() {
 
-  function assetsLoaded() {
-    text = new jaws.Text({text: "rect.png", width:20, height:20});
-    equal(text.width, 20, "text.width");
-    equal(text.height, 20, "text.height");
-  
-    text.scaleAll(2);
-    equal(text.rect().width, 40, "text.rect().width after scaling x2");
-    equal(text.rect().height, 40, "text.rect().height after scaling x2") ;
-  
-    deepEqual(text.rect(), new jaws.Rect(0,0,40,40), "text.rect()");
-	
-	text.style = "italic";
-	equal(text.style, "italic", "text.style changed to 'italic'");
-	
-	text.style = "bold";
-	equal(text.style, "bold", "text.style changed to 'bold'");
-  
-    text.setAnchor("bottom_right");
-    equal(text.x, text.rect().right, "text.x == text.rect().right when anchor is bottom_right");
-    equal(text.y, text.rect().bottom, "text.y == text.rect().bottom when anchor is bottom_right");
-    
-    text.setAnchor("top_left");
-    equal(text.x+text.width, text.rect().right, "text.x+text.width == text.rect().right when anchor is top_left");
-    equal(text.y+text.height, text.rect().bottom, "text.y+text.height == text.rect().bottom when anchor is top_left");
-  
-    text.rotateTo(45);
-    equal(text.angle, 45, "text.rotateTo() modifies angle");
-    text.rotate(45);
-    equal(text.angle, 90, "text.rotate() adds to angle #2");
-  
-    text.moveTo(100,100);
-    equal(text.x, 100, "text.moveTo() sets text x/y");
-    equal(text.y, 100, "text.moveTo() sets text x/y");
-  
-    text.move(10,12);
-    equal(text.x, 110, "text.move() adds to text x/y");
-    equal(text.y, 112, "text.move() adds to text x/y");
-  
-    text.scaleTo(1);
-    equal(text.width, 20, "text.scaleTo forces a scale_factor");
-  
-    text.setWidth(80);
-    equal(text.width, 80, "text.setWidth forces a new width via scale_x");
-    equal(text.scale_x, 4, "text.setWidth forces a new width via scale_x");
-  
-    text.setHeight(40);
-    equal(text.height, 40, "text.setHeight forces a new width via scale_y");
-    equal(text.scale_y, 2, "text.setHeight forces a new width via scale_y");
-  
-    text.resizeTo(20,20);
-    equal(text.width, 20, "resize() sets width via scale_x");
-    equal(text.height, 20, "resize() sets width via scale_x");
-    
-    text.resize(-10,-10);
-    equal(text.width, 10, "resize() mods width via scale_x");
-    equal(text.height, 10, "resize() mods width via scale_x");
-  
-    var flipped = text.flipped;
-    text.flip();
-    equal(text.flipped, !flipped, "text.flip inverts flipped");
-    text.flip();
-    equal(text.flipped, flipped, "text.flip inverts flipped");
-  
-    start();
-  }
-})
+  var text = new jaws.Text({text: "words", width: 40, height: 40, x: 0, y: 0});
+  equal(text.width, 40, "text.width");
+  equal(text.height, 40, "text.height");
+
+  deepEqual(text.rect(), new jaws.Rect(0, 0, 40, 40), "text.rect()");
+
+  text.style = "italic";
+  equal(text.style, "italic", "text.style changed to 'italic'");
+
+  text.style = "bold";
+  equal(text.style, "bold", "text.style changed to 'bold'");
+
+  text.setAnchor("bottom_right");
+  equal(text.x, text.rect().right, "text.x == text.rect().right when anchor is bottom_right");
+  equal(text.y, text.rect().bottom, "text.y == text.rect().bottom when anchor is bottom_right");
+
+  text.setAnchor("top_left");
+  equal(text.x + text.width, text.rect().right, "text.x+text.width == text.rect().right when anchor is top_left");
+  equal(text.y + text.height, text.rect().bottom, "text.y+text.height == text.rect().bottom when anchor is top_left");
+
+  text.rotateTo(45);
+  equal(text.angle, 45, "text.rotateTo() modifies angle");
+  text.rotate(45);
+  equal(text.angle, 90, "text.rotate() adds to angle #2");
+
+  text.moveTo(100, 100);
+  equal(text.x, 100, "text.moveTo() sets text x/y");
+  equal(text.y, 100, "text.moveTo() sets text x/y");
+
+  text.move(10, 12);
+  equal(text.x, 110, "text.move() adds to text x/y");
+  equal(text.y, 112, "text.move() adds to text x/y");
+
+  text.setWidth(80);
+  equal(text.width, 80, "text.setWidth forces a new width via scale_x");
+
+  text.setHeight(40);
+  equal(text.height, 40, "text.setHeight forces a new width via scale_y");
+
+  text.resizeTo(20, 20);
+  equal(text.width, 20, "resize() sets width via scale_x");
+  equal(text.height, 20, "resize() sets width via scale_x");
+
+  text.resize(-10, -10);
+  equal(text.width, 10, "resize() mods width via scale_x");
+  equal(text.height, 10, "resize() mods width via scale_x");
+
+});
 


### PR DESCRIPTION
Summary:
-- Text.js no longer supports scaling.*
-- Text.js now also has all of its functions documented in JSDocs format.
-- Unit tests for text.js have been updated and testing has been enabled again

(Note: It will need to be added back to jaws-dynamic.js too for testing to actually work.)

*Because Sprite.js uses its internal image property to create its scaling, it can rely on the fact that the property is basically a constant in all calculations. Its internal width and height can be scaled according to a factor multiplied by the size of the image (which never changes).

Text.js doesn't have that same relationship to its width and height. It is drawn /in/ and not /from/ its dimensions. This means that, should scaling be enabled, it would constantly be in flux as each new call to cacheOffsets would increase or decrease its internal width and height without the weight of something like an image.width to keep it as a factor.

It could still be added back in the future though. For the most accurate measurements, it should probably use the context.measureText for width and context.font for height values. However, both are relative to the font family used -- and the current object uses pixels instead of points anyway for size consistency.
