### PR TITLE
Update quadtree.js

### DIFF
--- a/src/extras/quadtree.js
+++ b/src/extras/quadtree.js
@@ -192,7 +192,9 @@ var jaws = (function(jaws) {
     });
 
     list1.forEach(function(el) {
-      overlap = jaws.collide(el, tree.retrieve(el), callback);
+      if(jaws.collide(el, tree.retrieve(el), callback)) {
+        overlap = true;
+      }
     });
 
     tree.clear();


### PR DESCRIPTION
The value of 'overlap' should reflect any possible collisions and not just the last tested comparison.
