### PR TITLE
Update text.js

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -73,8 +73,8 @@ var jaws = (function(jaws) {
     textBaseline: "alphabetic",
     text: "",
     wordWrap: false,
-    width: jaws.width,
-    height: jaws.height,
+    width: null,
+    height: null,
     shadowColor: null,
     shadowBlur: null,
     shadowOffsetX: null,
@@ -96,6 +96,9 @@ var jaws = (function(jaws) {
 
     if (this.anchor)
       this.setAnchor(this.anchor);
+      
+    this.width = options.width || jaws.width;
+    this.height = options.height || jaws.height;
 
     this.cacheOffsets();
 


### PR DESCRIPTION
Quick fix for making sure the width and height properties are always set to either the constructor options.value or to jaws.width and/or jaws.height.

(This was removed when the default values were changed. However, it's now a problem because width and height MUST have values and the default_options object wasn't passing on its width and height during instantiation.)
