### PR TITLE
Fix for Safari 5.1.7

### DIFF
--- a/test/audio.js
+++ b/test/audio.js
@@ -50,8 +50,8 @@ test("Audio", function() {
       audio3.unmute();
       equal(audio3.audio.mute, false, "The audio was unmuted");
 
-      audio3.seekTo(0.1);
-      equal(audio3.audio.currentTime, 0.1, "The currentTime was moved to 0.1");
+      audio3.seekTo(1.0);
+      equal(audio3.audio.currentTime, 1.0, "The currentTime was moved to 1.0");
     } else {
       equal(audio.audio, null, "No audio was loaded");
     }


### PR DESCRIPTION
There is bug in the current version of Safari that will return a slightly off result from the currentTime property of the HTML5 Audio object.

Seeking the file to fraction will result in a value that is the fraction plus the audio buffer offset. (A difference of 0.00004 in most cases.)

This passes the test for Safari.
