### PR TITLE
FIX jaws.collide with arrays of circles

### DIFF
--- a/src/collision_detection.js
+++ b/src/collision_detection.js
@@ -204,13 +204,13 @@ var jaws = (function(jaws) {
    *   jaws.collide(bullets, enemies, function(bullet, enemy) { ... } )
    */
   jaws.collide = function(x, x2, callback) {
-    if (x.rect && x2.forEach)
+    if ((x.rect || x.radius) && x2.forEach)
       return (jaws.collideOneWithMany(x, x2, callback).length > 0);
     if (x.forEach && x2.forEach)
       return (jaws.collideManyWithMany(x, x2, callback).length > 0);
-    if (x.forEach && x2.rect)
+    if (x.forEach && (x2.rect || x2.radius))
       return (jaws.collideOneWithMany(x2, x, callback).length > 0);
-    if (x.rect && x2.rect) {
+    if ((x.rect && x2.rect) || (x.radius && x2.radius)) {
       var result = jaws.collideOneWithOne(x, x2);
       if (callback && result)
         callback(x, x2);

--- a/test/collision_detection.js
+++ b/test/collision_detection.js
@@ -44,9 +44,8 @@ test("collision detection", function() {
     ok( jaws.collide(sprite1, sprite2), "true if any collisions" )
     ok( jaws.collide(sprites, sprites), "true if any collisions" )
 
-    // TODO: revisit these two tests:
-    //ok( jaws.collide(circle1, circle2), "true if any collisions" )
-    //ok( jaws.collide(circle1, circles), "true if any collisions" )
+    ok( jaws.collide(circle1, circle2), "true if any collisions" )
+    ok( jaws.collide(circle1, circles), "true if any collisions" )
 
     start();
   }
@@ -113,8 +112,12 @@ test("Collision detection with callbacks", function() {
     ok(callback_status, "collide() with circles callback got executed at least once")
 
     callback_status = false
+    jaws.collide(circle1, circle3, function(a, b) { callback_status = true }); 
+    deepEqual(callback_status, false, "collide(circle1, circle3) shouldn't execute callback")
+
+    callback_status = false
     jaws.collide(circle1, circle2, function(a, b) { callback_status = true }); 
-    deepEqual(callback_status, false, "collide(circle1, circle2) shouldn't executed callback")
+    ok(callback_status, "collide(circle1, circle2) shouldn't executed callback")
 
     start();
   }


### PR DESCRIPTION
`jaws.collide` doesn't work when colliding a circle vs a list of circles or a list of circles vs another list of circles. This patch fixes:
- Circles vs Circles collisions in `jaws.collide`
- Two tests in `collision detection` that were commented that tested these circles vs circles case.
- A test in `collision detection with callbacks` that was expecting a non-collision between two colliding circles (?)

PS: I haven't run `build.rb`, so if this pull request gets through, it will need to be re-run.
