### PR TITLE
Added <meta> tag with char encoding to examples

### DIFF
--- a/examples/example0.html
+++ b/examples/example0.html
@@ -1,9 +1,10 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
-    <title>Jaws Example #12 - As minimalistic as JawsJS can get</title>
+    <title>Jaws Example #0 - As minimalistic as JawsJS can get</title>
   </head>
 <body>
   <div id="info">
@@ -17,14 +18,14 @@
       player = new jaws.Sprite({image: "plane.png", x: jaws.width/2, y:jaws.height/2, anchor: "center"})
       jaws.preventDefaultKeys(["up", "down", "left", "right"])
     }
-    
+
     function update() {
       if(jaws.pressed("left"))  { player.x -= 2 }
       if(jaws.pressed("right")) { player.x += 2 }
       if(jaws.pressed("up"))    { player.y -= 2 }
       if(jaws.pressed("down"))  { player.y += 2 }
     }
-    
+
     function draw() {
       jaws.clear()
       player.draw()
@@ -32,7 +33,7 @@
 
     // Looks for <canvas> or <div id="canvas"> to draw on. Creates <canvas> if niether is found.
     // Then load predined-assets, call setup(), then loop update() and draw() in 60 FPS.
-    jaws.start()  
+    jaws.start()
   </script>
 
 </body>

--- a/examples/example1.html
+++ b/examples/example1.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>Jaws Example #1 - Sprite(), pressed(), basic game loop</title>
@@ -18,10 +19,10 @@
     We make our own canvas, instead of having jaws generate one (or several) for us.
     We get the canvas-tag from the DOM, fetch its context and send it to Sprite.
     If you for some reason want to have your own canvas tag this is the way to do it.
-    Add "?debug=1" to the URL and jaws will create a small window with debuginfo: 
+    Add "?debug=1" to the URL and jaws will create a small window with debuginfo:
     <a href="example1.html?debug=1">Switch to debug mode</a> | <a href="example1.html">Remove debug window</a>
   </div>
- 
+
   <script>
     var player
     var canvas
@@ -43,7 +44,7 @@
       jaws.on_keydown("esc", setup)
       jaws.preventDefaultKeys(["up", "down", "left", "right", "space"])
     }
-    
+
     /* step1. execute the game logic */
     function update() {
       if(jaws.pressed("left"))  { player.x -= 2 }
@@ -56,18 +57,18 @@
       forceInsideCanvas(player)
       bullets.removeIf(isOutsideCanvas)
     }
-    
+
     /* step2. draw the update state on screen */
     function draw() {
       jaws.clear()        // Same as: context.clearRect(0,0,jaws.width,jaws.height)
-       
+
       player.draw()
       bullets.draw()  // will call draw() on all items in the list
 
       info_tag.innerHTML = "FPS: " + jaws.game_loop.fps + " Player position: " + player.x + "/" + player.y + ". W/H: " + canvas.width + "/" + canvas.height
       fps.innerHTML = jaws.game_loop.fps
     }
-    
+
     /* 2 functions that will help us remove bullets outside the canvas + keep the plane within the canvas. */
     function isOutsideCanvas(item) { return (item.x < 0 || item.y < 0 || item.x > canvas.width || item.y > canvas.height) }
     function forceInsideCanvas(item) {
@@ -84,7 +85,7 @@
       this.draw = function() {
         this.x += 4
         context.beginPath();
-        context.arc(this.x, this.y, 4, 0, Math.PI*2, true); 
+        context.arc(this.x, this.y, 4, 0, Math.PI*2, true);
         context.stroke();
       }
     }

--- a/examples/example10.html
+++ b/examples/example10.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <script src="../game_states/edit.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
@@ -11,7 +12,7 @@
   <canvas width=500 height=400></canvas>
 
   <div id="jaws-edit">Editor output will show here.</div>
-  
+
   <div id="info">
     <h1>press SPACE to start editor</h1>
     <h2 style="color: red">** This example is WIP and currently doesn't work as intended ***</h2><br /><br />
@@ -24,15 +25,15 @@
     DEL: removes selected items <br />
     +: Adds new object (exprimental)<br/>
   </div>
-  
+
   <h3>jaws log</h3>
   <div id="jaws-log"></div>
- 
+
 i  <script>
     function Example() {
       var blocks = new jaws.SpriteList()
       var title = window.location.href  // Use URL as unique identifier when saving/fetching game objects from localStorage
-     
+
       this.setup = function() {
         // blocks.load(localStorage[title])  // Load  saved sprites from localStorage
         blocks.load( jaws.assets.get("/game_objects.json") )  // Load
@@ -44,13 +45,13 @@ i  <script>
           }
         }
 
-        jaws.on_keydown(["esc","space"], function() { 
+        jaws.on_keydown(["esc","space"], function() {
           /*
           * Start editor by switching game state to a new isntance of jaws.game_states.Edit
           * By specing an url, editor will POST a dump of all sprites to that url when saving.
           *
           * Example backend in sinatra (Ruby web framework):
-          *  
+          *
           * post "/game_objects.json" do
           *   File.open("public/game_objects.json", "w") do |fh|
           *     fh.puts params[:game_objects]
@@ -62,7 +63,7 @@ i  <script>
         })
         jaws.preventDefaultKeys(["space"])
       }
-      
+
       this.draw = function() {
         jaws.clear()
         blocks.draw()
@@ -71,11 +72,11 @@ i  <script>
 
     var Grass = function(options) { options.image = "grass.png"; jaws.Sprite.call(this, options) }
     var Block = function(options) { options.image = "block.bmp"; jaws.Sprite.call(this, options) }
-    
+
     jaws.onload = function() {
       Grass.prototype = new jaws.Sprite({})
       Grass.prototype.constructor = Grass
-      
+
       Block.prototype = new jaws.Sprite({})
       Block.prototype.constructor = Block
 

--- a/examples/example11.html
+++ b/examples/example11.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>Jaws Example #11 - Sprite(), pressed(), basic game loop</title>
@@ -18,14 +19,14 @@
     This will pre-scale player.png using a nearest neighbor algo (blocky retro style).
     NOTE: Scaling Big images can make browser "hang" for 2-3-4 seconds.
   </div>
- 
+
   <script>
     var player
     var info_tag
     var fps
 
     play_state = {
-      setup: function() {  
+      setup: function() {
         fps = document.getElementById("fps")
         info_tag = document.getElementsByTagName('info')
 
@@ -33,7 +34,7 @@
         player = jaws.Sprite({image: prescaled_image, x: 50, y:50, anchor: "center"}) // jaws.Sprite also works without 'new'
         jaws.preventDefaultKeys("up", "down", "left", "right", "space")
       },
-      
+
       update: function() {
         jaws.forceInsideCanvas(player)
         if(jaws.pressed("left"))  { player.x -= 2 }
@@ -41,9 +42,9 @@
         if(jaws.pressed("up"))    { player.y -= 2 }
         if(jaws.pressed("down"))  { player.y += 2 }
       },
-      
+
       draw: function() {
-        jaws.clear()        
+        jaws.clear()
         player.draw()
         info_tag.innerHTML = "FPS: " + jaws.game_loop.fps + " Player position: " + player.x + "/" + player.y
         fps.innerHTML = jaws.game_loop.fps

--- a/examples/example12.html
+++ b/examples/example12.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>Jaws Example #12 - TileMap() and ViewPort()</title>
@@ -9,16 +10,16 @@
 
   <canvas width=500 height=320></canvas>
   FPS: <span id="fps"></span>. Move with arrow keys.
-  
+
   <div id="info">
     <h1>TileMap and ViewPort optimizations</h1>
     Here we have a Huge game world consisting of 700 x 700 tiles ( ~half a million sprites ).
     We don't want to draw them all so we use viewport.drawTileMap( tile_map )
   </div>
-  
+
   <h3>jaws log</h3>
   <div id="jaws-log"></div>
- 
+
   <script>
     function Example() {
       var player
@@ -39,7 +40,7 @@
             blocks.push( new Sprite({image: "grass.png", x: i*32, y: i2*32}) )
           }
         }
-        
+
         //blocks.push( new Sprite({image: "grass.png", x: 0, y: 0}) )
         viewport = new jaws.Viewport({max_x: width*32, max_y: height*32})
 
@@ -51,7 +52,7 @@
         tile_map.push(blocks)
 
         player = new jaws.Sprite({x:10, y:10, scale: 2, anchor: "center"})
-        
+
         var anim = new jaws.Animation({sprite_sheet: "droid_11x15.png", frame_size: [11,15], frame_duration: 100})
         player.anim_default = anim.slice(0,5)
         player.anim_up = anim.slice(6,8)
@@ -78,8 +79,8 @@
       /* Directly after each update draw() will be called. Put all your on-screen operations here. */
       this.draw = function() {
         jaws.clear()
-        /* 
-        * blocks & tile_map  = ~500.000 sprites 
+        /*
+        * blocks & tile_map  = ~500.000 sprites
         */
 
         // Slow
@@ -94,7 +95,7 @@
         viewport.draw( player )
       }
     }
-    
+
     jaws.onload = function() {
       jaws.unpack()
       jaws.assets.add(["droid_11x15.png","block.bmp","grass.png"])

--- a/examples/example13.html
+++ b/examples/example13.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <script src="../game_states/edit.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
@@ -11,19 +12,19 @@
   <canvas width=500 height=400></canvas>
 
   <div id="jaws-edit">Editor output will show here.</div>
-  
+
   <div id="info">
     <h1>press SPACE to start editor</h1>
   </div>
-  
+
   <h3>jaws log</h3>
   <div id="jaws-log"></div>
- 
+
   <script>
     var blocks;
     function Example() {
       blocks = new jaws.SpriteList()
-     
+
       this.setup = function() {
         // blocks.load(localStorage[title])  // Load  saved sprites from localStorage
 
@@ -37,7 +38,7 @@
         jaws.preventDefaultKeys(["space"])
         startEdit();
       }
-      
+
       this.draw = function() {
         jaws.clear()
         blocks.draw()
@@ -45,21 +46,21 @@
     }
 
     function startEdit() {
-      jaws.switchGameState( 
+      jaws.switchGameState(
         new jaws.game_states.Edit({constructors: [Grass, Dirt], game_objects: blocks, grid_size: [30,15], isometric: true, title: window.location.href})
       )
     }
 
     var Grass = function(options) { options.image = "isometric_grass.bmp"; options.scale_image=2; jaws.Sprite.call(this, options) }
     var Dirt = function(options)  { options.image = "isometric_dirt.bmp"; options.scale_image=2; jaws.Sprite.call(this, options) }
-    
+
     jaws.onload = function() {
       Grass.prototype = new jaws.Sprite({})
       Grass.prototype.constructor = Grass
-      
+
       Dirt.prototype = new jaws.Sprite({})
       Dirt.prototype.constructor = Dirt
-     
+
       jaws.assets.add(["isometric_grass.bmp", "isometric_dirt.bmp"])
       jaws.start(Example)
     }

--- a/examples/example14.html
+++ b/examples/example14.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws.js"></script>
     <title>Jaws Example #14 - TileMap pathfinding</title>
   </head>
@@ -8,38 +9,38 @@
 
   <canvas width="320" height="320" style="background:white;"></canvas>
   <p>FPS: <span id="fps"></span>. Click a dirt tile to move. Find the hiding villain.</p>
-  
+
   <div id="info">
     <h1>Example 14: Pathfinding and Line of Sight in a TileMap</h1>
   </div>
- 
+
   <script>
     function Rouge() {
       var player, evil_player
       var walls
       var fps
-      
+
       var floor
-      
+
       var sprite_sheet
 
       /* Called once when a game state is activated. Use it for one-time setup code. */
       this.setup = function() {
         fps = document.getElementById("fps")
-        
+
         sprite_sheet = new jaws.SpriteSheet({image: "example14/basic-32.png", frame_size: [32,32]})
-        
+
         walls = new jaws.SpriteList()
-        
+
         floor = new jaws.SpriteList()
-        
+
         /* We create some 32x32 blocks and save them in array blocks */
         for (var i=0 ; i<10; i++)
         {
             for (var j=0 ; j<10; j++)
             {
                 floor.push( new Sprite({image: sprite_sheet.frames[5], x: i*32, y: j*32}) )
-                
+
                 if (i==0)
                 {
                     walls.push( new Sprite({image: sprite_sheet.frames[0], x: i, y: j*32}) )
@@ -52,12 +53,12 @@
                 }
             }
         }
-        
+
         // custom placed walls
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 96, y: 64}) )
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 96, y: 96}) )
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 64, y: 96}) )
-        
+
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 128, y: 160}) )
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 128, y: 192}) )
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 128, y: 224}) )
@@ -65,14 +66,14 @@
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 192, y: 160}) )
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 160, y: 224}) )
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 192, y: 224}) )
-        
+
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 32, y: 7*32}) )
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 64, y: 7*32}) )
         walls.push( new Sprite({image: sprite_sheet.frames[0], x: 64, y: 8*32}) )
 
         // A tilemap, each cell is 32x32 pixels. There's 10 such cells across and 10 downwards.
         var wall_map = new jaws.TileMap({size: [10,10], cell_size: [32,32]})
-        
+
         var floor_map = new jaws.TileMap({size: [10,10], cell_size: [32,32]})
         floor_map.push(floor)
 
@@ -83,7 +84,7 @@
         player = new jaws.Sprite({image: "example14/player.png", x:64, y:64, anchor: "top_left"})
         player.destination = false
         player.path = []
-        player.move = function(x, y) 
+        player.move = function(x, y)
         {
           // Have our tile map return the items that occupy the cells which are touched by player.rect
           // If there's any items inside player.rect, reverse the movement (-> stand still)
@@ -96,7 +97,7 @@
           this.y += y
           if(wall_map.atRect(player.rect()).length > 0) { this.y -= y; }
         }
-        
+
         player.moveTo = function(x, y)
         {
           /**
@@ -105,7 +106,7 @@
           this.path = wall_map.findPath([this.x, this.y], [x, y])
           this.setDestination()
         }
-        
+
         player.setDestination = function()
         {
           if (this.path.length > 0)
@@ -114,7 +115,7 @@
           }
           else { this.destination = false }
         }
-        
+
         evil_player = new jaws.Sprite({image: "example14/player.png", x:160, y:192, anchor: "bottom_right", angle:180})
         evil_player.visible = function()
         {
@@ -131,13 +132,13 @@
       this.update = function()
       {
         if (jaws.pressed("left_mouse_button") && !jaws.isOutsideCanvas({x: jaws.mouse_x, y: jaws.mouse_y, width: 1, height: 1}) && !player.destination) { player.moveTo(jaws.mouse_x, jaws.mouse_y) }
-        
+
         //move player
         if (player.x == player.destination.x && player.y == player.destination.y)
         {
           player.setDestination()
         }
-        
+
         if (player.destination)
         {
           if(player.x > player.destination.x)
@@ -174,7 +175,7 @@
         }
       }
     }
-    
+
     jaws.onload = function()
     {
       jaws.unpack()

--- a/examples/example2.html
+++ b/examples/example2.html
@@ -1,19 +1,20 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>Jaws Example #2 - on_keydown(), game states</title>
   </head>
 <body>
-    
+
     <canvas width=500 height=300 id="canvas"></canvas>
     FPS: <span id="fps"></span>. Move with arrows, shoot with space. Select with Return.
 
     <div id="info">
       <h1>Game states</h1>
       Minimalistic example using all jaws convenience methods and game states.
-      Game states are an proven and robust way of separating various parts of the game. 
+      Game states are an proven and robust way of separating various parts of the game.
       For example: An intro, a menu, the actual game play, the high score list. That's 4 different game states right there.
       <br /><br />
       A gamestate is just an normal javascript object with the methods setup(), update() and draw().
@@ -48,7 +49,7 @@
         if(jaws.pressed("right d")) { player.x += 2 }
         if(jaws.pressed("up w"))    { player.y -= 2 }
         if(jaws.pressed("down s"))  { player.y += 2 }
-        if(jaws.pressed("space enter")) { 
+        if(jaws.pressed("space enter")) {
           if(player.can_fire) {
             bullets.push( new Bullet(player.rect().right, player.y) )
             player.can_fire = false
@@ -69,8 +70,8 @@
 
       /* Simular to example1 but now we're using jaws properties to get width and height of canvas instead */
       /* This mainly since we let jaws handle the canvas now */
-      function isOutsideCanvas(item) { 
-        return (item.x < 0 || item.y < 0 || item.x > jaws.width || item.y > jaws.height) 
+      function isOutsideCanvas(item) {
+        return (item.x < 0 || item.y < 0 || item.x > jaws.width || item.y > jaws.height)
       }
       function forceInsideCanvas(item) {
         if(item.x < 0)                  { item.x = 0  }
@@ -116,7 +117,7 @@
           jaws.context.fillStyle =  (i == index) ? "Red" : "Black"
           jaws.context.strokeStyle =  "rgba(200,200,200,0.0)"
           jaws.context.fillText(items[i], 30, 100 + i * 60)
-        }  
+        }
       }
     }
 

--- a/examples/example3.html
+++ b/examples/example3.html
@@ -1,15 +1,16 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>Jaws Example #3 - Animation</title>
   </head>
 <body>
-    
+
   <canvas width=500 height=300></canvas>
   FPS: <span id="fps"></span>. Move with arrow keys.
-    
+
   <div id="info">
     <h1>Animations</h1>
     Showing of a "complex" animation, all cut up from a spritesheet.
@@ -18,7 +19,7 @@
 
   <h3>jaws log</h3>
   <div id="jaws-log"></div>
- 
+
   <script>
     /*
     * A good practice in even a smalish game is to use "game states"
@@ -40,7 +41,7 @@
         player.anim_down = anim.slice(8,10)
         player.anim_left = anim.slice(10,12)
         player.anim_right = anim.slice(12,14)
-      
+
         player.setImage( player.anim_default.next() )
         jaws.preventDefaultKeys(["up", "down", "left", "right", "space"])
       }
@@ -57,11 +58,11 @@
 
       /* Directly after each update draw() will be called. Put all your on-screen operations here. */
       this.draw = function() {
-        jaws.clear()       
+        jaws.clear()
         jaws.log(player)
         player.draw()
       }
-    
+
       /* Force given item's x/y to stay within canvas borders */
       function forceInsideCanvas(item) {
         if(item.x < 0)                  { item.x = 0  }
@@ -70,7 +71,7 @@
         if(item.bottom  > jaws.height)  { item.y = jaws.height - item.height }
       }
     }
-    
+
     jaws.onload = function() {
       jaws.assets.add("droid_11x15.png")
       jaws.start(Example3)  // Our convenience function jaws.start() will load assets, call setup and loop update/draw in 60 FPS

--- a/examples/example4.html
+++ b/examples/example4.html
@@ -1,15 +1,16 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>Jaws Example #4 - Collision detection</title>
   <head>
 <body style="width: 800px;">
-  
+
   <canvas width=800 height=400 style="width: 800px; height: 400px;"></canvas>
   FPS: <span id="fps"></span>
-  
+
   <div id="info">
     <h1>Sprite collision detection</h1>
     <code>PLUS / +</code>: Add sprites<br>
@@ -19,10 +20,10 @@
     Every Sprite (that has an image) will have a function rect() which will return a Rect-object just embracing the sprite.
     Then you can <code>sprite.rect.collideRect(rect2)</code> or <code>sprite.rect.collidePoint(x, y)</code>
   </div>
-  
+
   <h3>jaws log</h3>
   <div id="jaws-log"></div>
- 
+
   <script>
     function Example4() {
       var sprites = new jaws.SpriteList()
@@ -52,7 +53,7 @@
           if(collision_detection_mode == "normal")          collision_detection_mode = "quadtree";
           else if(collision_detection_mode == "quadtree")   collision_detection_mode = "normal";
         }
-       
+
         // OLD WAY:
         //if(jaws.pressed("space")) {
         //  if(!space_down & collision_detection_mode == "normal")          collision_detection_mode = "quadtree";
@@ -60,11 +61,11 @@
         //  space_down = true
         //}
         //else { space_down = false }
-        
+
         sprites.forEach(function(sprite, index) {
           sprite.collision = false
           sprite.move(sprite.vx, sprite.vy)
- 
+
           if(sprite.x < 0 || sprite.rect().right > jaws.width)    { sprite.vx = -sprite.vx }
           if(sprite.y < 0 || sprite.rect().bottom > jaws.height)  { sprite.vy = -sprite.vy }
         })
@@ -105,7 +106,7 @@
         return sprite
       }
     }
-    
+
     window.onload = function() {
       jaws.assets.add("rect.png")
       jaws.start(Example4)

--- a/examples/example5.html
+++ b/examples/example5.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>Jaws Example #5 - Sprite.anchor()</title>
@@ -9,17 +10,17 @@
 
   <canvas width=1000 height=200></canvas>
   FPS: <span id="fps"></span>
-  
+
   <div id="info">
     <h1>Sprite.anchor</h1>
     Showing off the effects of setting different anchors for different sprites.
     Set anchor when creating a Sprite:
     <code>ship = new Sprite({image: "spaceship.png", anchor: "center"})</code>
   </div>
-  
+
   <h3>jaws log</h3>
   <div id="jaws-log"></div>
- 
+
   <script>
     function Example5() {
       var anchors = ["top_left", "top_center", "top_right", "center_left", "center", "center_bottom", "bottom_left", "bottom_center", "bottom_right"]
@@ -36,7 +37,7 @@
         for(var i=0; i < 9; i++) {
           var sprite = new jaws.Sprite({image: "rect.png", x: (50.5 + i*100), y: 100, anchor: anchors[i]})
           sprites.push(sprite)
-          
+
           jaws.context.fillText(anchors[i], sprite.x, 150)
           jaws.context.fillText("anchor_x: " + sprite.anchor_x, sprite.x, 165)
           jaws.context.fillText("anchor_y: " + sprite.anchor_y, sprite.x, 180)
@@ -45,7 +46,7 @@
         }
         jaws.context.moveTo(0, 100)
         jaws.context.lineTo(jaws.width, 100)
- 
+
         jaws.context.stroke();
       }
 

--- a/examples/example6.html
+++ b/examples/example6.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>Jaws Example #6 - Parallax()</title>
@@ -20,7 +21,7 @@
     <script>
     function ParallaxDemo() {
       var fps = document.getElementById("fps")
-      
+
       this.setup = function() {
         this.parallax = new jaws.Parallax({repeat_x: true})
         this.parallax.addLayer({image: "parallax_1.png", damping: 100})
@@ -35,7 +36,7 @@
         else { this.parallax.camera_x += 2 }
         fps.innerHTML = jaws.game_loop.fps
       }
-      
+
       this.draw = function() {
         this.parallax.draw();
       }

--- a/examples/example7.html
+++ b/examples/example7.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>DOMtest</title>
@@ -45,7 +46,7 @@
       if(jaws.pressed("right")) { player.vx = 4; player.flipped = false; player.angle = 20 }
       if(jaws.pressed("up"))    { player.vy = -4 }
       if(jaws.pressed("down"))  { player.vy = 4 }
-      if(jaws.pressed("space")) { 
+      if(jaws.pressed("space")) {
         if(player.can_fire) {
           var vx = player.flipped ? -10 : 10
           bullets.push( new Bullet({x: player.rect().right, y: player.rect().bottom-5, vx: vx, vy: 0}) )
@@ -83,8 +84,8 @@
 
     /* Simular to example1 but now we're using jaws properties to get widthteElement('div'); and height of canvas instead */
     /* This mainly since we let jaws handle the canvas now */
-    function isOutsideCanvas(item) { 
-      return (item.x < 0 || item.y < 0 || item.x > jaws.width || item.y > jaws.height) 
+    function isOutsideCanvas(item) {
+      return (item.x < 0 || item.y < 0 || item.x > jaws.width || item.y > jaws.height)
     }
     function forceInsideCanvas(item) {
       if(item.x < 0)                          { item.x = 0  }
@@ -102,9 +103,9 @@
       delete options.vy
       options.image = "bullet.png"
       jaws.Sprite.call(this, options)
-      
-      this.update = function() { 
-        this.x += this.vx 
+
+      this.update = function() {
+        this.x += this.vx
         this.y += this.vy
       }
     }

--- a/examples/example8.html
+++ b/examples/example8.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>Jaws Example #8 - TileMap()</title>
@@ -9,16 +10,16 @@
 
   <canvas width=500 height=320></canvas>
   FPS: <span id="fps"></span>. Move with arrow keys.
-  
+
   <div id="info">
     <h1>TileMap</h1>
     With TileMap() we can fit game objects into a 2D array, we call it cells. You set the size for the cells, default is 32 x 32 pixels.
     Once we have the objects in our tile map we can lookup game objects very fast.
   </div>
-  
+
   <h3>jaws log</h3>
   <div id="jaws-log"></div>
- 
+
   <script>
     function Example() {
       var player
@@ -29,7 +30,7 @@
       this.setup = function() {
         fps = document.getElementById("fps")
         blocks = new jaws.SpriteList()
-        
+
         /* We create some 32x32 blocks and save them in array blocks */
         blocks.push( new Sprite({image: "block.bmp", x: 0, y: 0}) )
         blocks.push( new Sprite({image: "block.bmp", x: 64, y: 64}) )
@@ -46,7 +47,7 @@
         player = new jaws.Sprite({x:110, y:120, scale: 2, anchor: "center"})
         player.move = function(x, y) {
           jaws.log("Player: " + player.rect().toString())
-          
+
           // Have our tile map return the items that occupy the cells which are touched by player.rect
           // If there's any items inside player.rect, reverse the movement (-> stand still)
           this.x += x
@@ -91,7 +92,7 @@
         // player.rect.draw()
       }
     }
-    
+
     jaws.onload = function() {
       jaws.unpack()
       jaws.assets.add(["droid_11x15.png","block.bmp"])

--- a/examples/example9.html
+++ b/examples/example9.html
@@ -1,6 +1,7 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html>
   <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <script src="../jaws-dynamic.js"></script>
     <link type="text/css" rel="stylesheet" href="style.css" />
     <title>Jaws Example #9 - Viewport()</title>
@@ -10,15 +11,15 @@
   <canvas width=500 height=320></canvas>
   Move with arrow keys.
   <div id="live_info"></div>
-  
+
   <div id="info">
     <h1>ViewPort and TileMap</h1>
-    Viewport() demo. 
+    Viewport() demo.
   </div>
-  
+
   <h3>jaws log</h3>
   <div id="jaws-log"></div>
- 
+
   <script>
     function Example() {
       var player
@@ -34,7 +35,7 @@
         live_info = document.getElementById("live_info")
         blocks = new jaws.SpriteList()
         var world = new jaws.Rect(0,0,320*10,320*2)
-        
+
         /* We create some 32x32 blocks and save them in array blocks */
         for(var y = 0; y < world.height; y += 32 ) {
           blocks.push( new Sprite({image: "block.bmp", x: 0, y: y}) )
@@ -47,7 +48,7 @@
           blocks.push( new Sprite({image: "block.bmp", x: x, y: world.height-64}) )
         }
         for(var i=0; i < 50; i++) {
-          blocks.push( new Sprite({image: "block.bmp", x: parseInt(Math.random()*100)*32, y: world.height - parseInt(Math.random()*10)*32}) ) 
+          blocks.push( new Sprite({image: "block.bmp", x: parseInt(Math.random()*100)*32, y: world.height - parseInt(Math.random()*10)*32}) )
         }
 
         // A tile map, each cell is 32x32 pixels. There's 100 such cells across and 100 downwards.
@@ -62,17 +63,17 @@
 
         player.move = function() {
           this.x += this.vx
-          if(tile_map.atRect(player.rect()).length > 0) { 
-            this.x -= this.vx 
+          if(tile_map.atRect(player.rect()).length > 0) {
+            this.x -= this.vx
           }
           this.vx = 0
 
           this.y += this.vy
           var block = tile_map.atRect(player.rect())[0]
-          if(block) { 
+          if(block) {
             // Heading downwards
-            if(this.vy > 0) { 
-              this.can_jump = true 
+            if(this.vy > 0) {
+              this.can_jump = true
               this.y = block.rect().y - 1
             }
             // Heading upwards (jumping)
@@ -133,7 +134,7 @@
         });
       }
     }
-    
+
     jaws.onload = function() {
       jaws.unpack()
       jaws.assets.add(["droid_11x15.png","block.bmp"])


### PR DESCRIPTION
added <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/> to <head>
changed title for example0.html from "example #12"  to "example #0"
text editor also automatically removed trailing spaces (the other 100+ changes)..

can resubmit if preferred